### PR TITLE
fix: disable auto-collapse

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -126,11 +126,6 @@ const config = {
           apiKey: 'AeeRpiguwfTpmcKHGbBkTmUCkjoPg8nh',
         },
         contextualSearch: true,
-      },
-      docs: {
-        sidebar: {
-          autoCollapseCategories: true,
-        }
       }
     }),
 


### PR DESCRIPTION
Docusaurus isn't build to handle the same pages being added to the sidebar, so when auto-collapse is on, no matter the page you are clicking, it select the last one, which is an unwanted behaviour. When it's off, it select the page everywhere, which is also unwanted, but less a problem as it stick to the page you choose at least.