### PR TITLE
fix: Kubefirst website URL (close #295)

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -103,7 +103,7 @@ const config = {
           },
           {
             href: 'https:/kubefirst.io',
-            label: 'kubefirst.io',
+            label: 'Website',
             position: 'right',
           },
         ],


### PR DESCRIPTION
Seems like there's a bug with Docusaurus that take the label as the URL instead of the href content, so it's why I put a work, instead of kubefirst.io: it fixed the issue