### PR TITLE
chore: bump chart version

### DIFF
--- a/charts/docs/Chart.yaml
+++ b/charts/docs/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: 8c5fd0ea4e0523c953b317fc5fe9fa89dac9688f
 description: A Helm chart for Kubernetes
 name: docs
 type: application
-version: 0.5.0
+version: 0.5.1


### PR DESCRIPTION
hoping to bypass the GitHub Action release issue with chart versions for a quick deployment of the new documentation