### PR TITLE
ci: fix markdown link check

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@master
 
       - name: Validate Links Markdown ${{ matrix.file-extension }} files
-        if: success() || failure()
+        if: always()
         uses: gaurav-nelson/github-action-markdown-link-check@v1
         with:
           config-file: '.markdownlinkcheck.json'


### PR DESCRIPTION
always run the second check even if the first one failed so all files will be reported if they have issues: wil prevent seeing issues on MDX files on the next run of the action after fixing issues in MD files (example)