### PR TITLE
ci: wait for previous release action before continuing

### DIFF
--- a/.github/workflows/check-commits.yml
+++ b/.github/workflows/check-commits.yml
@@ -4,13 +4,13 @@ on: push
 jobs:
   commitlint:
     runs-on: ubuntu-latest
-
     steps:
+
       - name: Checkout the code
         uses: actions/checkout@main
         with:
           fetch-depth: 0
-      
+
       - name: Lint the commits
         uses: wagoid/commitlint-github-action@v5
         with:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -6,8 +6,6 @@ env:
   ARGO_VERSION: v3.4.1
   CONTAINER_REGISTRY_URL: 'public.ecr.aws/kubefirst'
 
-concurrency: ci-release-docs
-
 on:
   push:
     branches:
@@ -22,12 +20,16 @@ jobs:
     if: ${{ github.actor != 'kube1st' }}
     runs-on: self-hosted
     steps:
+
+      - name: Wait for other releases processes to finish
+        uses: ahmadnassri/action-workflow-queue@v1.1.4
+
       - name: Setup Runner for Argo
         run: |
-          cd $HOME
+          cd "$HOME"
           echo "Install argo"
           # Download the binary
-          curl -sLO https://github.com/argoproj/argo-workflows/releases/download/${ARGO_VERSION}/argo-linux-amd64.gz
+          curl -sLO "https://github.com/argoproj/argo-workflows/releases/download/${ARGO_VERSION}/argo-linux-amd64.gz"
           # Unzip
           gunzip argo-linux-amd64.gz
           # Make binary executable


### PR DESCRIPTION
When a PR is merged to main, while another one was merged and not deployed on production, a Helm chart issue may arise. Unfortunately, the concurrency option from GitHub Actions cancel previous pending actions, which is not the intented result we want (there is no way yet to change this behaviour https://github.com/orgs/community/discussions/41518). It's usually not a problem as new PR needs to be updated with main content, but it may prevent a deployment is the new PR isn't on the docs: the new release action wouldn't run, and the old one be cancelled, you the previous PR changes to the docs wouldn't be published until the next PR, or manual run of the action. Trying this waiting action as if it's working well, it could solve the issue.