### PR TITLE
chore: bump the chart to deploy the docs

### DIFF
--- a/charts/docs/Chart.yaml
+++ b/charts/docs/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: 6efa2ad
 description: Kubefirst documentation Helm chart
 name: docs
 type: application
-version: 0.48.0
+version: 0.49.0


### PR DESCRIPTION
An deployment issue happened previously, but I don't have access to the workflow logs anymore as I changed the job name...