### PR TITLE
fix: v.next docs using v.next content for MDX imports (3/3 fix for #441)

### DIFF
--- a/docs/aws/advanced/certificates.mdx
+++ b/docs/aws/advanced/certificates.mdx
@@ -2,7 +2,7 @@
 title: Certificates
 ---
 
-import * as config from "@site/docs/constants.js"
+import * as config from "../../constants.js"
 
 <div
   style={{

--- a/docs/aws/advanced/install.mdx
+++ b/docs/aws/advanced/install.mdx
@@ -8,9 +8,10 @@ image: "https://docs.kubefirst.io/img/logo.svg"
 ---
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
-import styles from "@site/docs/stylesheets/tabs.module.css";
-import ReactDom from 'react-dom'
-import * as config from "@site/docs/constants.js"
+import styles from "../../stylesheets/tabs.module.css";
+import * as config from "../../constants.js"
+import GitHubInstall from '../partials/github/_install.mdx'
+import GitLabInstall from '../partials/gitlab/_install.mdx'
 
 <div
   style={{
@@ -23,9 +24,6 @@ import * as config from "@site/docs/constants.js"
     <img src={config.AWS_LOGO_URL} height="50" width="120" />
   </div>
 </div>
-
-import GitHubInstall from '@site/docs/aws/partials/github/_install.mdx'
-import GitLabInstall from '@site/docs/aws/partials/gitlab/_install.mdx'
 
 <Tabs groupId="git_provider" defaultValue="github" queryString>
     <TabItem

--- a/docs/aws/advanced/security.mdx
+++ b/docs/aws/advanced/security.mdx
@@ -2,7 +2,7 @@
 title: Security
 ---
 
-import * as config from "@site/docs/constants.js"
+import * as config from "../../constants.js"
 
 <div
   style={{

--- a/docs/aws/credits.mdx
+++ b/docs/aws/credits.mdx
@@ -6,6 +6,6 @@ description: how to destroy your kubefirst platform
 image: "https://docs.kubefirst.io/img/logo.svg"
 ---
 
-import Credits from "@site/docs/common/credits.mdx"
+import Credits from "../common/credits.mdx"
 
 <Credits />

--- a/docs/aws/deprovision.mdx
+++ b/docs/aws/deprovision.mdx
@@ -6,6 +6,6 @@ description: how to destroy your kubefirst platform
 image: "https://docs.kubefirst.io/img/logo.svg"
 ---
 
-import Deprovision from '@site/docs/common/deprovision.mdx'
+import Deprovision from '../common/deprovision.mdx'
 
 <Deprovision />

--- a/docs/aws/explore/argocd.mdx
+++ b/docs/aws/explore/argocd.mdx
@@ -3,6 +3,6 @@ title: Argo CD
 sidebar_position: 1
 ---
 
-import ExploreArgocd from "@site/docs/common/argocd.mdx"
+import ExploreArgocd from "../../common/argocd.mdx"
 
 <ExploreArgocd />

--- a/docs/aws/explore/gitops.mdx
+++ b/docs/aws/explore/gitops.mdx
@@ -4,6 +4,6 @@ sidebar_position: 2
 ---
 
 
-import ExploreGitOps from "@site/docs/common/gitops.mdx"
+import ExploreGitOps from "../../common/gitops.mdx"
 
 <ExploreGitOps />

--- a/docs/aws/explore/metaphor.mdx
+++ b/docs/aws/explore/metaphor.mdx
@@ -3,6 +3,6 @@ title: Metaphor
 sidebar_position: 3
 ---
 
-import ExploreMetaphor from "@site/docs/common/metaphor.mdx"
+import ExploreMetaphor from "../../common/metaphor.mdx"
 
 <ExploreMetaphor />

--- a/docs/aws/explore/platform.mdx
+++ b/docs/aws/explore/platform.mdx
@@ -3,6 +3,6 @@ title: Telemetry
 sidebar_position: 6
 ---
 
-import ExploreTelemetry from "@site/docs/common/telemetry.mdx"
+import ExploreTelemetry from "../../common/telemetry.mdx"
 
 <ExploreTelemetry />

--- a/docs/aws/explore/terraform.mdx
+++ b/docs/aws/explore/terraform.mdx
@@ -3,6 +3,6 @@ title: Terraform & Atlantis
 sidebar_position: 5
 ---
 
-import ExploreTerraform from "@site/docs/common/terraform.mdx"
+import ExploreTerraform from "../../common/terraform.mdx"
 
 <ExploreTerraform />

--- a/docs/aws/explore/user-creation.mdx
+++ b/docs/aws/explore/user-creation.mdx
@@ -4,10 +4,10 @@ sidebar_position: 5
 ---
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
-import styles from "@site/docs/stylesheets/tabs.module.css";
+import styles from "../../stylesheets/tabs.module.css";
 
-import GitHubUserCreation from '@site/docs/civo/partials/github/_user-creation.mdx'
-import GitLabUserCreation from '@site/docs/civo/partials/gitlab/_user-creation.mdx'
+import GitHubUserCreation from '../partials/github/_user-creation.mdx'
+import GitLabUserCreation from '../partials/gitlab/_user-creation.mdx'
 
 <Tabs groupId="git_provider" defaultValue="github" queryString>
     <TabItem value="github" label="GitHub" attributes={{className: styles.github}}>

--- a/docs/aws/explore/vault.mdx
+++ b/docs/aws/explore/vault.mdx
@@ -3,6 +3,6 @@ title: Vault
 sidebar_position: 4
 ---
 
-import ExploreVault from "@site/docs/common/vault.mdx"
+import ExploreVault from "../../common/vault.mdx"
 
 <ExploreVault />

--- a/docs/aws/faq.mdx
+++ b/docs/aws/faq.mdx
@@ -6,6 +6,6 @@ description: frequently asked quesitons about the platform
 image: "https://docs.kubefirst.io/img/logo.svg"
 ---
 
-import FAQ from "@site/docs/common/faq.mdx"
+import FAQ from "../common/faq.mdx"
 
 <FAQ />

--- a/docs/aws/gitops-catalog.mdx
+++ b/docs/aws/gitops-catalog.mdx
@@ -9,6 +9,6 @@ keywords:
 image: 'https://docs.kubefirst.io/img/logo.svg'
 ---
 
-import GitOpsCatalog from '@site/docs/common/gitops-catalog.mdx';
+import GitOpsCatalog from '../common/gitops-catalog.mdx';
 
 <GitOpsCatalog />

--- a/docs/aws/overview.mdx
+++ b/docs/aws/overview.mdx
@@ -9,10 +9,10 @@ image: "https://docs.kubefirst.io/img/logo.svg"
 
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
-import styles from "@site/docs/stylesheets/tabs.module.css";
+import styles from "../stylesheets/tabs.module.css";
 import ReactDom from 'react-dom'
-import * as config from "@site/docs/constants.js"
-import CommonProvisionProcess from "@site/docs/common/partials/common/_provision-process.mdx";
+import * as config from "../constants.js"
+import CommonProvisionProcess from "../common/partials/common/_provision-process.mdx";
 
 <div
   style={{
@@ -26,8 +26,8 @@ import CommonProvisionProcess from "@site/docs/common/partials/common/_provision
   </div>
 </div>
 
-import GitHubOverview from '@site/docs/aws/partials/github/_overview.mdx'
-import GitLabOverview from '@site/docs/aws/partials/gitlab/_overview.mdx'
+import GitHubOverview from '../aws/partials/github/_overview.mdx'
+import GitLabOverview from '../aws/partials/gitlab/_overview.mdx'
 
 # Overview
 

--- a/docs/aws/partials/github/_cluster-create.mdx
+++ b/docs/aws/partials/github/_cluster-create.mdx
@@ -1,4 +1,4 @@
-import CloudflareDNS from "@site/docs/common/partials/common/_cloudflare-dns.mdx";
+import CloudflareDNS from "../../../common/partials/common/_cloudflare-dns.mdx";
 
 ## Create your new kubefirst cluster
 

--- a/docs/aws/partials/github/_user-creation.mdx
+++ b/docs/aws/partials/github/_user-creation.mdx
@@ -1,0 +1,62 @@
+## Platform User Onboarding
+
+In this tutorial we will show how to add users to your platform through [Atlantis](https://www.runatlantis.io/), which will allow a preview of how changes made will be expressed through Terraform before branches are merged into your repository.
+
+Navigate to the `gitops` repository in your GitHub org, clone the contents, and create a new branch:
+
+```shell
+cd gitops
+git checkout -b new-user
+```
+
+The folder `aws-github/terraform/users/admins` contains two separate files that represent admin users: `admin-one.tf` (commented-out), and the kbot user in the `kbot.tf` file. Here's the module from `admin-one.tf`:
+
+```terraform
+module "admin_one" {
+  source = "./modules/user/github"
+
+  acl_policies            = ["admin"]
+  email                   = "your.admin@your-company.io"
+  first_name              = "Admin"
+  github_username         = "admin-one-github-username"
+  last_name               = "One"
+  team_id                 = data.github_team.admins.id
+  username                = "aone"
+  user_disabled           = false
+  userpass_accessor       = data.vault_auth_backend.userpass.accessor
+}
+```
+
+Uncomment and edit this code to replace the values for the `email`, `first_name`, `github_username`, `last_name`, and `username` before pushing to your branch.
+
+Note: If you are doing using this walkthrough simply to test Atlantis, you do not need to update these fields to be accurate.
+
+```shell
+git add .
+git commit -m feat: add new user
+git push --set-upstream origin new-user
+```
+
+Create a pull request. This will kick off the Atlantis workflow. Within a minute or so of submitting the pull request, a comment will appear on the pull request that shows the Terraform plan with the changes it will be making to your infrastructure.
+
+![Atlantis Plan Comment Example](../../../img/common/github/atlantis-comments.png)
+
+To apply these changes, you or someone in the organization can submit a comment on that pull request with the following comment text:
+
+`atlantis apply`
+
+Doing so will instruct Atlantis to apply the plan. It will report back with the results of the apply within a minute or so.
+
+NOTE: Atlantis merges your pull request automatically once an apply is successfully executed. Don't merge Terraform pull requests yourself.
+
+Atlantis will always run plans automatically for you when a pull request is opened that changes files mapped in `atlantis.yaml`.
+
+Any new users you have created through this process will have their temporary initial passwords stored in your Vault cluster. You can access Vault using the root login credentials provided to you during your kubefirst installation. Only the root Vault token can access these secrets. You will find your users' initial passwords in the Vault secret store `/secrets/users/<username>`.
+
+![vault token login](../../../img/kubefirst/local/vault-token-login.png)
+
+Once you've provided them their initial password, they can update their own password throughout the platform by updating their user password entity in Vault. Anyone can change their own password, and Admins can reset anyone's password. These rules, just like everything else on kubefirst, can be configured in your new `gitops` repository.
+
+![default user creation](../../../img/kubefirst/local/default-user-creation.png)
+
+The admins and developers that you add through IaC will automatically propagate to all tools due to the Vault OIDC provider that's preconfigured throughout the kubefirst platform tools.

--- a/docs/aws/partials/gitlab/_cluster-create.mdx
+++ b/docs/aws/partials/gitlab/_cluster-create.mdx
@@ -1,4 +1,4 @@
-import CloudflareDNS from "@site/docs/common/partials/common/_cloudflare-dns.mdx";
+import CloudflareDNS from "../../../common/partials/common/_cloudflare-dns.mdx";
 
 ## Create your new kubefirst cluster
 

--- a/docs/aws/partials/gitlab/_user-creation.mdx
+++ b/docs/aws/partials/gitlab/_user-creation.mdx
@@ -1,0 +1,63 @@
+## Platform User Onboarding
+
+In this tutorial we will show how to add users to your platform through [Atlantis](https://www.runatlantis.io/), which will allow a preview of how changes made will be expressed through Terraform before branches are merged into your repository.
+
+Navigate to the `gitops` repository in your GitLab group, clone the contents, and create a new branch:
+
+```shell
+cd gitops
+git checkout -b new-user
+```
+
+The folder `aws-gitlab/terraform/users/admins` contains two separate files that represent admin users: `admin-one.tf` (commented-out), and the kbot user in the `kbot.tf` file. Here's the module from `admin-one.tf`:
+
+```terraform
+module "admin_one" {
+  source = "../modules/user"
+
+  acl_policies            = ["admin"]
+  email                   = "your.admin@your-company.io"
+  first_name              = "Admin"
+  fullname                = "Admin One"
+  group_id                = data.vault_identity_group.admins.group_id
+  gitlab_username         = "your-admins-gitlab-username"
+  last_name               = "One"
+  username                = "aone"
+  user_disabled           = false
+  userpass_accessor       = data.vault_auth_backend.userpass.accessor
+}
+```
+
+Uncomment and edit this code to replace the values for the `email`, `first_name`, `gitlab_username`, `last_name`, and `username` before pushing to your branch.
+
+Note: If you are doing using this walkthrough simply to test Atlantis, you do not need to update these fields to be accurate.
+
+```shell
+git add .
+git commit -m feat: add new user
+git push --set-upstream origin new-user
+```
+
+Create a merge request. This will kick off the Atlantis workflow. Within a minute or so of submitting the merge request, a comment will appear on the merge request that shows the Terraform plan with the changes it will be making to your infrastructure.
+
+![Atlantis Plan Comment Example](../../../img/common/gitlab/atlantis-comments.png)
+
+To apply these changes, you or someone in the organization can submit a comment on that merge request with the following comment text:
+
+`atlantis apply`
+
+Doing so will instruct Atlantis to apply the plan. It will report back with the results of the apply within a minute or so.
+
+NOTE: Atlantis merges your merge request automatically once an apply is successfully executed. Don't merge Terraform merge requests yourself.
+
+Atlantis will always run plans automatically for you when a merge request is opened that changes files mapped in `atlantis.yaml`.
+
+Any new users you have created through this process will have their temporary initial passwords stored in your Vault cluster. You can access Vault using the root login credentials provided to you during your kubefirst installation. Only the root Vault token can access these secrets. You will find your users' initial passwords in the Vault secret store `/secrets/users/<username>`.
+
+![vault token login](../../../img/kubefirst/local/vault-token-login.png)
+
+Once you've provided them their initial password, they can update their own password throughout the platform by updating their user password entity in Vault. Anyone can change their own password, and Admins can reset anyone's password. These rules, just like everything else on kubefirst, can be configured in your new `gitops` repository.
+
+![default user creation](../../../img/kubefirst/local/default-user-creation.png)
+
+The admins and developers that you add through IaC will automatically propagate to all tools due to the Vault OIDC provider that's preconfigured throughout the kubefirst platform tools.

--- a/docs/aws/quick-start/install/cli.mdx
+++ b/docs/aws/quick-start/install/cli.mdx
@@ -9,18 +9,18 @@ image: "https://docs.kubefirst.io/img/logo.svg"
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 
-import GitHubClusterCreateCmd from "@site/docs/aws/partials/github/_cluster-create.mdx";
-import GitLabClusterCreateCmd from "@site/docs/aws/partials/gitlab/_cluster-create.mdx";
+import GitHubClusterCreateCmd from "../../partials/github/_cluster-create.mdx";
+import GitLabClusterCreateCmd from "../../partials/gitlab/_cluster-create.mdx";
 
-import CommonCloudPrerequisites from "@site/docs/aws/partials/common/_prerequisites.mdx";
-import CommonClusterConnectivity from "@site/docs/aws/partials/common/_cluster-connectivity.mdx";
-import CommonGitHubPrerequisites from "@site/docs/common/partials/github/_prerequisites.mdx";
-import CommonGitLabPrerequisites from "@site/docs/common/partials/gitlab/_prerequisites.mdx";
-import AWSRootCredentialsCmd from "@site/docs/aws/partials/common/_root-credentials-cmd.mdx";
-import CommonTerminalOutput from "@site/docs/common/partials/common/_terminal-output.mdx";
+import CommonCloudPrerequisites from "../../partials/common/_prerequisites.mdx";
+import CommonClusterConnectivity from "../../partials/common/_cluster-connectivity.mdx";
+import CommonGitHubPrerequisites from "../../../common/partials/github/_prerequisites.mdx";
+import CommonGitLabPrerequisites from "../../../common/partials/gitlab/_prerequisites.mdx";
+import AWSRootCredentialsCmd from "../../partials/common/_root-credentials-cmd.mdx";
+import CommonTerminalOutput from "../../../common/partials/common/_terminal-output.mdx";
 
-import * as config from "@site/docs/constants.js"
-import styles from "@site/docs/stylesheets/tabs.module.css";
+import * as config from "../../../constants.js"
+import styles from "../../../stylesheets/tabs.module.css";
 
 export const TabLabel = ({ imgSrc, label }) => (
   <div className="git-tab">

--- a/docs/aws/quick-start/repositories.mdx
+++ b/docs/aws/quick-start/repositories.mdx
@@ -9,11 +9,10 @@ image: "https://docs.kubefirst.io/img/logo.svg"
 
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
-import styles from "@site/docs/stylesheets/tabs.module.css";
-import ReactDom from 'react-dom'
-import * as config from "@site/docs/constants.js"
-import GitHubRepositories from '@site/docs/aws/partials/github/_repositories.mdx'
-import GitLabRepositories from '@site/docs/aws/partials/gitlab/_repositories.mdx'
+import styles from "../../stylesheets/tabs.module.css";
+import * as config from "../../constants.js"
+import GitHubRepositories from '../partials/github/_repositories.mdx'
+import GitLabRepositories from '../partials/gitlab/_repositories.mdx'
 
 <div
   style={{

--- a/docs/civo/credits.mdx
+++ b/docs/civo/credits.mdx
@@ -6,6 +6,6 @@ description: credit to all the awesome open source projects
 image: "https://docs.kubefirst.io/img/logo.svg"
 ---
 
-import CommonCredits from "@site/docs/common/credits.mdx"
+import CommonCredits from "../common/credits.mdx"
 
 <CommonCredits />

--- a/docs/civo/deprovision.mdx
+++ b/docs/civo/deprovision.mdx
@@ -9,6 +9,6 @@ keywords:
 image: "https://docs.kubefirst.io/img/logo.svg"
 ---
 
-import Deprovision from '@site/docs/common/deprovision.mdx'
+import Deprovision from '../common/deprovision.mdx'
 
 <Deprovision />

--- a/docs/civo/explore/argocd.mdx
+++ b/docs/civo/explore/argocd.mdx
@@ -3,6 +3,6 @@ title: Argo CD
 sidebar_position: 1
 ---
 
-import ExploreArgocd from "@site/docs/common/argocd.mdx"
+import ExploreArgocd from "../../common/argocd.mdx"
 
 <ExploreArgocd />

--- a/docs/civo/explore/gitops.mdx
+++ b/docs/civo/explore/gitops.mdx
@@ -4,6 +4,6 @@ sidebar_position: 2
 ---
 
 
-import ExploreGitOps from "@site/docs/common/gitops.mdx"
+import ExploreGitOps from "../../common/gitops.mdx"
 
 <ExploreGitOps />

--- a/docs/civo/explore/metaphor.mdx
+++ b/docs/civo/explore/metaphor.mdx
@@ -3,6 +3,6 @@ title: Metaphor
 sidebar_position: 3
 ---
 
-import ExploreMetaphor from "@site/docs/common/metaphor.mdx"
+import ExploreMetaphor from "../../common/metaphor.mdx"
 
 <ExploreMetaphor />

--- a/docs/civo/explore/telemetry.mdx
+++ b/docs/civo/explore/telemetry.mdx
@@ -3,6 +3,6 @@ title: Telemetry
 sidebar_position: 7
 ---
 
-import ExploreTelemetry from "@site/docs/common/telemetry.mdx"
+import ExploreTelemetry from "../../common/telemetry.mdx"
 
 <ExploreTelemetry />

--- a/docs/civo/explore/terraform.mdx
+++ b/docs/civo/explore/terraform.mdx
@@ -3,6 +3,6 @@ title: Terraform & Atlantis
 sidebar_position: 4
 ---
 
-import ExploreTerraform from "@site/docs/common/terraform.mdx"
+import ExploreTerraform from "../../common/terraform.mdx"
 
 <ExploreTerraform />

--- a/docs/civo/explore/user-creation.mdx
+++ b/docs/civo/explore/user-creation.mdx
@@ -4,9 +4,9 @@ sidebar_position: 5
 ---
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
-import styles from "@site/docs/stylesheets/tabs.module.css";
-import GitHubUserCreation from '@site/docs/civo/partials/github/_user-creation.mdx'
-import GitLabUserCreation from '@site/docs/civo/partials/gitlab/_user-creation.mdx'
+import styles from "../../stylesheets/tabs.module.css";
+import GitHubUserCreation from '../partials/github/_user-creation.mdx'
+import GitLabUserCreation from '../partials/gitlab/_user-creation.mdx'
 
 <Tabs groupId="git_provider" defaultValue="github" queryString>
     <TabItem

--- a/docs/civo/explore/vault.mdx
+++ b/docs/civo/explore/vault.mdx
@@ -3,6 +3,6 @@ title: Vault
 sidebar_position: 6
 ---
 
-import ExploreVault from "@site/docs/common/vault.mdx"
+import ExploreVault from "../../common/vault.mdx"
 
 <ExploreVault />

--- a/docs/civo/faq.mdx
+++ b/docs/civo/faq.mdx
@@ -6,7 +6,7 @@ description: frequently asked quesitons about the kubefirst platform
 image: "https://docs.kubefirst.io/img/logo.svg"
 ---
 
-import FAQ from "@site/docs/common/faq.mdx"
+import FAQ from "../common/faq.mdx"
 
 <FAQ />
 

--- a/docs/civo/gitops-catalog.mdx
+++ b/docs/civo/gitops-catalog.mdx
@@ -9,6 +9,6 @@ keywords:
 image: 'https://docs.kubefirst.io/img/logo.svg'
 ---
 
-import GitOpsCatalog from '@site/docs/common/gitops-catalog.mdx';
+import GitOpsCatalog from '../common/gitops-catalog.mdx';
 
 <GitOpsCatalog />

--- a/docs/civo/overview.mdx
+++ b/docs/civo/overview.mdx
@@ -9,13 +9,13 @@ image: "https://docs.kubefirst.io/img/logo.svg"
 
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
-import styles from "@site/docs/stylesheets/tabs.module.css";
+import styles from "../stylesheets/tabs.module.css";
 import ReactDom from 'react-dom'
-import * as config from "@site/docs/constants.js"
-import GitHubOverview from '@site/docs/civo/partials/github/_overview.mdx'
-import GitLabOverview from '@site/docs/civo/partials/gitlab/_overview.mdx'
+import * as config from "../constants.js"
+import GitHubOverview from '../civo/partials/github/_overview.mdx'
+import GitLabOverview from '../civo/partials/gitlab/_overview.mdx'
 import CloudBanner from '@site/src/components/CloudBanner/CloudBanner.jsx'
-import CommonProvisionProcess from "@site/docs/common/partials/common/_provision-process.mdx";
+import CommonProvisionProcess from "../common/partials/common/_provision-process.mdx";
 
 <div
   style={{

--- a/docs/civo/partials/github/_cluster-create.mdx
+++ b/docs/civo/partials/github/_cluster-create.mdx
@@ -1,4 +1,4 @@
-import CloudflareDNS from "@site/docs/common/partials/common/_cloudflare-dns.mdx";
+import CloudflareDNS from "../../../common/partials/common/_cloudflare-dns.mdx";
 
 ## Create your new kubefirst cluster
 

--- a/docs/civo/partials/gitlab/_cluster-create.mdx
+++ b/docs/civo/partials/gitlab/_cluster-create.mdx
@@ -1,4 +1,4 @@
-import CloudflareDNS from "@site/docs/common/partials/common/_cloudflare-dns.mdx";
+import CloudflareDNS from "../../../common/partials/common/_cloudflare-dns.mdx";
 
 ## Create your new kubefirst cluster
 

--- a/docs/civo/platform.mdx
+++ b/docs/civo/platform.mdx
@@ -6,6 +6,6 @@ description: an overview of kubefirst
 image: "https://docs.kubefirst.io/img/logo.svg"
 ---
 
-import Platform from "@site/docs/common/platform.mdx"
+import Platform from "../common/platform.mdx"
 
 <Platform />

--- a/docs/civo/quick-start/install/cli.mdx
+++ b/docs/civo/quick-start/install/cli.mdx
@@ -9,18 +9,18 @@ image: "https://docs.kubefirst.io/img/logo.svg"
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 
-import GitHubPrerequisites from "@site/docs/common/partials/github/_prerequisites.mdx";
-import GitHubClusterCreateCmd from "@site/docs/civo/partials/github/_cluster-create.mdx";
+import GitHubPrerequisites from "../../../common/partials/github/_prerequisites.mdx";
+import GitHubClusterCreateCmd from "../../partials/github/_cluster-create.mdx";
 
-import GitLabPrerequisites from "@site/docs/common/partials/gitlab/_prerequisites.mdx";
-import GitLabClusterCreateCmd from "@site/docs/civo/partials/gitlab/_cluster-create.mdx";
+import GitLabPrerequisites from "../../../common/partials/gitlab/_prerequisites.mdx";
+import GitLabClusterCreateCmd from "../../partials/gitlab/_cluster-create.mdx";
 
-import CommonCloudPrerequisites from "@site/docs/civo/partials/common/_prerequisites.mdx";
-import CommonClusterConnectivity from "@site/docs/civo/partials/common/_cluster-connectivity.mdx";
-import CommonRootCredentialsCmd from "@site/docs/civo/partials/common/_root-credentials-cmd.mdx";
+import CommonCloudPrerequisites from "../../partials/common/_prerequisites.mdx";
+import CommonClusterConnectivity from "../../partials/common/_cluster-connectivity.mdx";
+import CommonRootCredentialsCmd from "../../partials/common/_root-credentials-cmd.mdx";
 
-import * as config from "@site/docs/constants.js"
-import styles from "@site/docs/stylesheets/tabs.module.css";
+import * as config from "../../../constants.js"
+import styles from "../../../stylesheets/tabs.module.css";
 
 export const TabLabel = ({ imgSrc, label }) => (
   <div className="git-tab">

--- a/docs/civo/quick-start/repositories.mdx
+++ b/docs/civo/quick-start/repositories.mdx
@@ -9,11 +9,10 @@ image: "https://docs.kubefirst.io/img/logo.svg"
 
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
-import styles from "@site/docs/stylesheets/tabs.module.css";
-import ReactDom from 'react-dom'
-import * as config from "@site/docs/constants.js"
-import GitHubRepositories from '@site/docs/civo/partials/github/_repositories.mdx'
-import GitLabRepositories from '@site/docs/civo/partials/gitlab/_repositories.mdx'
+import styles from "../../stylesheets/tabs.module.css";
+import * as config from "../../constants.js"
+import GitHubRepositories from '../partials/github/_repositories.mdx'
+import GitLabRepositories from '../partials/gitlab/_repositories.mdx'
 
 <div
   style={{

--- a/docs/common/git-auth.mdx
+++ b/docs/common/git-auth.mdx
@@ -5,10 +5,10 @@ id: gitAuth
 
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
-import styles from "@site/docs/stylesheets/tabs.module.css";
-import GitHubTokens from '@site/docs/common/partials/github/_tokens.mdx'
-import GitLabTokens from '@site/docs/common/partials/gitlab/_tokens.mdx'
-import * as config from "@site/docs/constants.js"
+import styles from "../stylesheets/tabs.module.css";
+import GitHubTokens from '../common/partials/github/_tokens.mdx'
+import GitLabTokens from '../common/partials/gitlab/_tokens.mdx'
+import * as config from "../constants.js"
 
 <div
   style={{

--- a/docs/gcp/credits.mdx
+++ b/docs/gcp/credits.mdx
@@ -6,6 +6,6 @@ description: credit to all the awesome open source projects
 image: "https://docs.kubefirst.io/img/logo.svg"
 ---
 
-import CommonCredits from "@site/docs/common/credits.mdx"
+import CommonCredits from "../common/credits.mdx"
 
 <CommonCredits />

--- a/docs/gcp/deprovision.mdx
+++ b/docs/gcp/deprovision.mdx
@@ -9,6 +9,6 @@ keywords:
 image: "https://docs.kubefirst.io/img/logo.svg"
 ---
 
-import Deprovision from '@site/docs/common/deprovision.mdx'
+import Deprovision from '../common/deprovision.mdx'
 
 <Deprovision />

--- a/docs/gcp/explore/argocd.mdx
+++ b/docs/gcp/explore/argocd.mdx
@@ -3,6 +3,6 @@ title: Argo CD
 sidebar_position: 1
 ---
 
-import ExploreArgocd from "@site/docs/common/argocd.mdx"
+import ExploreArgocd from "../../common/argocd.mdx"
 
 <ExploreArgocd />

--- a/docs/gcp/explore/gitops.mdx
+++ b/docs/gcp/explore/gitops.mdx
@@ -4,6 +4,6 @@ sidebar_position: 2
 ---
 
 
-import ExploreGitOps from "@site/docs/common/gitops.mdx"
+import ExploreGitOps from "../../common/gitops.mdx"
 
 <ExploreGitOps />

--- a/docs/gcp/explore/metaphor.mdx
+++ b/docs/gcp/explore/metaphor.mdx
@@ -3,6 +3,6 @@ title: Metaphor
 sidebar_position: 3
 ---
 
-import ExploreMetaphor from "@site/docs/common/metaphor.mdx"
+import ExploreMetaphor from "../../common/metaphor.mdx"
 
 <ExploreMetaphor />

--- a/docs/gcp/explore/telemetry.mdx
+++ b/docs/gcp/explore/telemetry.mdx
@@ -3,6 +3,6 @@ title: Telemetry
 sidebar_position: 7
 ---
 
-import ExploreTelemetry from "@site/docs/common/telemetry.mdx"
+import ExploreTelemetry from "../../common/telemetry.mdx"
 
 <ExploreTelemetry />

--- a/docs/gcp/explore/terraform.mdx
+++ b/docs/gcp/explore/terraform.mdx
@@ -3,6 +3,6 @@ title: Terraform & Atlantis
 sidebar_position: 4
 ---
 
-import ExploreTerraform from "@site/docs/common/terraform.mdx"
+import ExploreTerraform from "../../common/terraform.mdx"
 
 <ExploreTerraform />

--- a/docs/gcp/explore/user-creation.mdx
+++ b/docs/gcp/explore/user-creation.mdx
@@ -5,9 +5,9 @@ sidebar_position: 5
 
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
-import styles from "@site/docs/stylesheets/tabs.module.css";
-import GitHubUserCreation from '@site/docs/gcp/partials/github/_user-creation.mdx'
-import GitLabUserCreation from '@site/docs/gcp/partials/gitlab/_user-creation.mdx'
+import styles from "../../stylesheets/tabs.module.css";
+import GitHubUserCreation from '../partials/github/_user-creation.mdx'
+import GitLabUserCreation from '../partials/gitlab/_user-creation.mdx'
 
 <Tabs groupId="git_provider" defaultValue="github" queryString>
     <TabItem

--- a/docs/gcp/explore/vault.mdx
+++ b/docs/gcp/explore/vault.mdx
@@ -3,6 +3,6 @@ title: Vault
 sidebar_position: 6
 ---
 
-import ExploreVault from "@site/docs/common/vault.mdx"
+import ExploreVault from "../../common/vault.mdx"
 
 <ExploreVault />

--- a/docs/gcp/faq.mdx
+++ b/docs/gcp/faq.mdx
@@ -6,6 +6,6 @@ description: frequently asked quesitons about the kubefirst platform
 image: "https://docs.kubefirst.io/img/logo.svg"
 ---
 
-import FAQ from "@site/docs/common/faq.mdx"
+import FAQ from "../common/faq.mdx"
 
 <FAQ />

--- a/docs/gcp/overview.mdx
+++ b/docs/gcp/overview.mdx
@@ -9,13 +9,13 @@ image: "https://docs.kubefirst.io/img/logo.svg"
 ---
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
-import styles from "@site/docs/stylesheets/tabs.module.css";
+import styles from "../stylesheets/tabs.module.css";
 import ReactDom from 'react-dom'
-import * as config from "@site/docs/constants.js"
-import GitHubOverview from '@site/docs/gcp/partials/github/_overview.mdx'
-import GitLabOverview from '@site/docs/gcp/partials/gitlab/_overview.mdx'
+import * as config from "../constants.js"
+import GitHubOverview from '../gcp/partials/github/_overview.mdx'
+import GitLabOverview from '../gcp/partials/gitlab/_overview.mdx'
 import CloudBanner from '@site/src/components/CloudBanner/CloudBanner.jsx'
-import CommonProvisionProcess from "@site/docs/common/partials/common/_provision-process.mdx";
+import CommonProvisionProcess from "../common/partials/common/_provision-process.mdx";
 
 <CloudBanner cloudImgUrl={config.GCP_LOGO_URL} />
 

--- a/docs/gcp/partials/github/_cluster-create.mdx
+++ b/docs/gcp/partials/github/_cluster-create.mdx
@@ -1,4 +1,4 @@
-import CloudflareDNS from "@site/docs/common/partials/common/_cloudflare-dns.mdx";
+import CloudflareDNS from "../../../common/partials/common/_cloudflare-dns.mdx";
 
 ## Create your new kubefirst cluster
 

--- a/docs/gcp/partials/gitlab/_cluster-create.mdx
+++ b/docs/gcp/partials/gitlab/_cluster-create.mdx
@@ -1,4 +1,4 @@
-import CloudflareDNS from "@site/docs/common/partials/common/_cloudflare-dns.mdx";
+import CloudflareDNS from "../../../common/partials/common/_cloudflare-dns.mdx";
 
 ## Create your new kubefirst cluster
 

--- a/docs/gcp/platform.mdx
+++ b/docs/gcp/platform.mdx
@@ -6,6 +6,6 @@ description: an overview of kubefirst
 image: "https://docs.kubefirst.io/img/logo.svg"
 ---
 
-import Platform from "@site/docs/common/platform.mdx"
+import Platform from "../common/platform.mdx"
 
 <Platform />

--- a/docs/gcp/quick-start/install/cli.mdx
+++ b/docs/gcp/quick-start/install/cli.mdx
@@ -9,18 +9,18 @@ image: "https://docs.kubefirst.io/img/logo.svg"
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 
-import GitHubPrerequisites from "@site/docs/common/partials/github/_prerequisites.mdx";
-import GitHubClusterCreateCmd from "@site/docs/gcp/partials/github/_cluster-create.mdx";
+import GitHubPrerequisites from "../../../common/partials/github/_prerequisites.mdx";
+import GitHubClusterCreateCmd from "../../partials/github/_cluster-create.mdx";
 
-import GitLabPrerequisites from "@site/docs/common/partials/gitlab/_prerequisites.mdx";
-import GitLabClusterCreateCmd from "@site/docs/gcp/partials/gitlab/_cluster-create.mdx";
+import GitLabPrerequisites from "../../../common/partials/gitlab/_prerequisites.mdx";
+import GitLabClusterCreateCmd from "../../partials/gitlab/_cluster-create.mdx";
 
-import CommonCloudPrerequisites from "@site/docs/gcp/partials/common/_prerequisites.mdx";
-import CommonClusterConnectivity from "@site/docs/gcp/partials/common/_cluster-connectivity.mdx";
-import CommonRootCredentialsCmd from "@site/docs/gcp/partials/common/_root-credentials-cmd.mdx";
+import CommonCloudPrerequisites from "../../partials/common/_prerequisites.mdx";
+import CommonClusterConnectivity from "../../partials/common/_cluster-connectivity.mdx";
+import CommonRootCredentialsCmd from "../../partials/common/_root-credentials-cmd.mdx";
 
-import * as config from "@site/docs/constants.js"
-import styles from "@site/docs/stylesheets/tabs.module.css";
+import * as config from "../../../constants.js"
+import styles from "../../../stylesheets/tabs.module.css";
 
 export const TabLabel = ({ imgSrc, label }) => (
   <div className="git-tab">

--- a/docs/gcp/quick-start/repositories.mdx
+++ b/docs/gcp/quick-start/repositories.mdx
@@ -9,11 +9,11 @@ image: "https://docs.kubefirst.io/img/logo.svg"
 
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
-import styles from "@site/docs/stylesheets/tabs.module.css";
+import styles from "../../stylesheets/tabs.module.css";
 import ReactDom from 'react-dom'
-import * as config from "@site/docs/constants.js"
-import GitHubRepositories from '@site/docs/gcp/partials/github/_repositories.mdx'
-import GitLabRepositories from '@site/docs/gcp/partials/gitlab/_repositories.mdx'
+import * as config from "../../constants.js"
+import GitHubRepositories from '../partials/github/_repositories.mdx'
+import GitLabRepositories from '../partials/gitlab/_repositories.mdx'
 
 <div
   style={{

--- a/docs/k3d/credits.mdx
+++ b/docs/k3d/credits.mdx
@@ -7,6 +7,6 @@ description: Credits for the awesome open source we use
 image: "https://docs.kubefirst.io/img/logo.svg"
 ---
 
-import Credits from "@site/docs/common/credits.mdx"
+import Credits from "../common/credits.mdx"
 
 <Credits />

--- a/docs/k3d/deprovision.mdx
+++ b/docs/k3d/deprovision.mdx
@@ -7,6 +7,6 @@ description: how to deprovision your kubefirst platform
 image: "https://docs.kubefirst.io/img/logo.svg"
 ---
 
-import Deprovision from '@site/docs/common/deprovision.mdx'
+import Deprovision from '../common/deprovision.mdx'
 
 <Deprovision />

--- a/docs/k3d/explore/argocd.mdx
+++ b/docs/k3d/explore/argocd.mdx
@@ -3,6 +3,6 @@ title: Argo CD
 sidebar_position: 2
 ---
 
-import ExploreArgocd from "@site/docs/common/argocd.mdx"
+import ExploreArgocd from "../../common/argocd.mdx"
 
 <ExploreArgocd />

--- a/docs/k3d/explore/gitops.mdx
+++ b/docs/k3d/explore/gitops.mdx
@@ -3,6 +3,6 @@ title: GitOps
 sidebar_position: 3
 ---
 
-import ExploreGitOps from "@site/docs/common/gitops.mdx"
+import ExploreGitOps from "../../common/gitops.mdx"
 
 <ExploreGitOps />

--- a/docs/k3d/explore/metaphor.mdx
+++ b/docs/k3d/explore/metaphor.mdx
@@ -3,6 +3,6 @@ title: Metaphor
 sidebar_position: 4
 ---
 
-import ExploreMetaphor from "@site/docs/common/metaphor.mdx"
+import ExploreMetaphor from "../../common/metaphor.mdx"
 
 <ExploreMetaphor />

--- a/docs/k3d/explore/telemetry.mdx
+++ b/docs/k3d/explore/telemetry.mdx
@@ -3,6 +3,6 @@ title: Telemetry
 sidebar_position: 8
 ---
 
-import ExploreTelemetry from "@site/docs/common/telemetry.mdx"
+import ExploreTelemetry from "../../common/telemetry.mdx"
 
 <ExploreTelemetry />

--- a/docs/k3d/explore/terraform.mdx
+++ b/docs/k3d/explore/terraform.mdx
@@ -3,6 +3,6 @@ title: Terraform & Atlantis
 sidebar_position: 5
 ---
 
-import ExploreTerraform from "@site/docs/common/terraform.mdx"
+import ExploreTerraform from "../../common/terraform.mdx"
 
 <ExploreTerraform />

--- a/docs/k3d/explore/user-creation.mdx
+++ b/docs/k3d/explore/user-creation.mdx
@@ -5,10 +5,10 @@ sidebar_position: 6
 
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
-import styles from "@site/docs/stylesheets/tabs.module.css";
+import styles from "../../stylesheets/tabs.module.css";
 
-import GitHubUserCreation from '@site/docs/civo/partials/github/_user-creation.mdx'
-import GitLabUserCreation from '@site/docs/civo/partials/gitlab/_user-creation.mdx'
+import GitHubUserCreation from '../partials/github/_user-creation.mdx'
+import GitLabUserCreation from '../partials/gitlab/_user-creation.mdx'
 
 <Tabs groupId="git_provider" defaultValue="github" queryString>
     <TabItem value="github" label="GitHub" attributes={{className: styles.github}}>

--- a/docs/k3d/explore/vault.mdx
+++ b/docs/k3d/explore/vault.mdx
@@ -3,6 +3,6 @@ title: Vault
 sidebar_position: 7
 ---
 
-import ExploreVault from "@site/docs/common/vault.mdx"
+import ExploreVault from "../../common/vault.mdx"
 
 <ExploreVault />

--- a/docs/k3d/faq.mdx
+++ b/docs/k3d/faq.mdx
@@ -7,7 +7,7 @@ description: frequently asked quesitons about the kubefirst platform
 image: "https://docs.kubefirst.io/img/logo.svg"
 ---
 
-import FAQ from "@site/docs/common/faq.mdx"
+import FAQ from "../common/faq.mdx"
 
 <FAQ />
 

--- a/docs/k3d/overview.mdx
+++ b/docs/k3d/overview.mdx
@@ -9,12 +9,12 @@ image: "https://docs.kubefirst.io/img/logo.svg"
 
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
-import styles from "@site/docs/stylesheets/tabs.module.css";
+import styles from "../stylesheets/tabs.module.css";
 import ReactDom from 'react-dom'
-import * as config from "@site/docs/constants.js"
-import CommonProvisionProcess from "@site/docs/common/partials/common/_provision-process.mdx";
-import GitHubOverview from '@site/docs/k3d/partials/github/_overview.mdx'
-import GitLabOverview from '@site/docs/k3d/partials/gitlab/_overview.mdx'
+import * as config from "../constants.js"
+import CommonProvisionProcess from "../common/partials/common/_provision-process.mdx";
+import GitHubOverview from '../k3d/partials/github/_overview.mdx'
+import GitLabOverview from '../k3d/partials/gitlab/_overview.mdx'
 
 <div
   style={{

--- a/docs/k3d/quick-start/install.mdx
+++ b/docs/k3d/quick-start/install.mdx
@@ -8,11 +8,10 @@ image: "https://docs.kubefirst.io/img/logo.svg"
 
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
-import styles from "@site/docs/stylesheets/tabs.module.css";
-import ReactDom from 'react-dom'
-import * as config from "@site/docs/constants.js"
-import GitHubInstall from '@site/docs/k3d/partials/github/_install.mdx'
-import GitLabInstall from '@site/docs/k3d/partials/gitlab/_install.mdx'
+import styles from "../../stylesheets/tabs.module.css";
+import * as config from "../../constants.js"
+import GitHubInstall from '../partials/github/_install.mdx'
+import GitLabInstall from '../partials/gitlab/_install.mdx'
 
 <div
   style={{

--- a/docs/k3d/quick-start/repositories.mdx
+++ b/docs/k3d/quick-start/repositories.mdx
@@ -8,11 +8,10 @@ image: "https://docs.kubefirst.io/img/logo.svg"
 
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
-import styles from "@site/docs/stylesheets/tabs.module.css";
-import ReactDom from 'react-dom'
-import * as config from "@site/docs/constants.js"
-import GitHubRepositories from '@site/docs/k3d/partials/github/_repositories.mdx'
-import GitLabRepositories from '@site/docs/k3d/partials/gitlab/_repositories.mdx'
+import styles from "../../stylesheets/tabs.module.css";
+import * as config from "../../constants.js"
+import GitHubRepositories from '../partials/github/_repositories.mdx'
+import GitLabRepositories from '../partials/gitlab/_repositories.mdx'
 
 <div
   style={{

--- a/docs/vultr/credits.mdx
+++ b/docs/vultr/credits.mdx
@@ -6,6 +6,6 @@ description: credit to all the awesome open source projects
 image: "https://docs.kubefirst.io/img/logo.svg"
 ---
 
-import CommonCredits from "@site/docs/common/credits.mdx"
+import CommonCredits from "../common/credits.mdx"
 
 <CommonCredits />

--- a/docs/vultr/deprovision.mdx
+++ b/docs/vultr/deprovision.mdx
@@ -9,6 +9,6 @@ keywords:
 image: 'https://docs.kubefirst.io/img/logo.svg'
 ---
 
-import Deprovision from '@site/docs/common/deprovision.mdx';
+import Deprovision from '../common/deprovision.mdx';
 
 <Deprovision />

--- a/docs/vultr/explore/argocd.mdx
+++ b/docs/vultr/explore/argocd.mdx
@@ -3,6 +3,6 @@ title: Argo CD
 sidebar_position: 1
 ---
 
-import ExploreArgocd from "@site/docs/common/argocd.mdx"
+import ExploreArgocd from "../../common/argocd.mdx"
 
 <ExploreArgocd />

--- a/docs/vultr/explore/gitops.mdx
+++ b/docs/vultr/explore/gitops.mdx
@@ -4,6 +4,6 @@ sidebar_position: 2
 ---
 
 
-import ExploreGitOps from "@site/docs/common/gitops.mdx"
+import ExploreGitOps from "../../common/gitops.mdx"
 
 <ExploreGitOps />

--- a/docs/vultr/explore/metaphor.mdx
+++ b/docs/vultr/explore/metaphor.mdx
@@ -3,6 +3,6 @@ title: Metaphor
 sidebar_position: 3
 ---
 
-import ExploreMetaphor from "@site/docs/common/metaphor.mdx"
+import ExploreMetaphor from "../../common/metaphor.mdx"
 
 <ExploreMetaphor />

--- a/docs/vultr/explore/telemetry.mdx
+++ b/docs/vultr/explore/telemetry.mdx
@@ -3,6 +3,6 @@ title: Telemetry
 sidebar_position: 7
 ---
 
-import ExploreTelemetry from "@site/docs/common/telemetry.mdx"
+import ExploreTelemetry from "../../common/telemetry.mdx"
 
 <ExploreTelemetry />

--- a/docs/vultr/explore/terraform.mdx
+++ b/docs/vultr/explore/terraform.mdx
@@ -3,6 +3,6 @@ title: Terraform & Atlantis
 sidebar_position: 4
 ---
 
-import ExploreTerraform from "@site/docs/common/terraform.mdx"
+import ExploreTerraform from "../../common/terraform.mdx"
 
 <ExploreTerraform />

--- a/docs/vultr/explore/user-creation.mdx
+++ b/docs/vultr/explore/user-creation.mdx
@@ -5,10 +5,10 @@ sidebar_position: 5
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
-import styles from '@site/docs/stylesheets/tabs.module.css';
+import styles from '../../stylesheets/tabs.module.css';
 
-import GitHubUserCreation from '@site/docs/vultr/partials/github/_user-creation.mdx';
-import GitLabUserCreation from '@site/docs/vultr/partials/gitlab/_user-creation.mdx';
+import GitHubUserCreation from '../partials/github/_user-creation.mdx';
+import GitLabUserCreation from '../partials/gitlab/_user-creation.mdx';
 
 <Tabs groupId="git_provider" defaultValue="github" queryString>
   <TabItem

--- a/docs/vultr/explore/vault.mdx
+++ b/docs/vultr/explore/vault.mdx
@@ -3,6 +3,6 @@ title: Vault
 sidebar_position: 6
 ---
 
-import ExploreVault from "@site/docs/common/vault.mdx"
+import ExploreVault from "../../common/vault.mdx"
 
 <ExploreVault />

--- a/docs/vultr/faq.mdx
+++ b/docs/vultr/faq.mdx
@@ -6,6 +6,6 @@ description: frequently asked quesitons about the kubefirst platform
 image: "https://docs.kubefirst.io/img/logo.svg"
 ---
 
-import FAQ from "@site/docs/common/faq.mdx"
+import FAQ from "../common/faq.mdx"
 
 <FAQ />

--- a/docs/vultr/overview.mdx
+++ b/docs/vultr/overview.mdx
@@ -9,13 +9,13 @@ image: 'https://docs.kubefirst.io/img/logo.svg'
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
-import styles from '@site/docs/stylesheets/tabs.module.css';
+import styles from '../stylesheets/tabs.module.css';
 import ReactDom from 'react-dom';
-import * as config from '@site/docs/constants.js';
-import GitHubOverview from '@site/docs/vultr/partials/github/_overview.mdx';
-import GitLabOverview from '@site/docs/vultr/partials/gitlab/_overview.mdx';
+import * as config from '../constants.js';
+import GitHubOverview from '../vultr/partials/github/_overview.mdx';
+import GitLabOverview from '../vultr/partials/gitlab/_overview.mdx';
 import CloudBanner from '@site/src/components/CloudBanner/CloudBanner.jsx';
-import CommonProvisionProcess from "@site/docs/common/partials/common/_provision-process.mdx";
+import CommonProvisionProcess from "../common/partials/common/_provision-process.mdx";
 
 <div
   style={{

--- a/docs/vultr/partials/github/_cluster-create.mdx
+++ b/docs/vultr/partials/github/_cluster-create.mdx
@@ -1,4 +1,4 @@
-import CloudflareDNS from "@site/docs/common/partials/common/_cloudflare-dns.mdx";
+import CloudflareDNS from "../../../common/partials/common/_cloudflare-dns.mdx";
 
 ## Create your new kubefirst cluster
 

--- a/docs/vultr/partials/gitlab/_cluster-create.mdx
+++ b/docs/vultr/partials/gitlab/_cluster-create.mdx
@@ -1,4 +1,4 @@
-import CloudflareDNS from "@site/docs/common/partials/common/_cloudflare-dns.mdx";
+import CloudflareDNS from "../../../common/partials/common/_cloudflare-dns.mdx";
 
 ## Create your new kubefirst cluster
 

--- a/docs/vultr/platform.mdx
+++ b/docs/vultr/platform.mdx
@@ -6,6 +6,6 @@ description: an overview of kubefirst
 image: "https://docs.kubefirst.io/img/logo.svg"
 ---
 
-import Platform from "@site/docs/common/platform.mdx"
+import Platform from "../common/platform.mdx"
 
 <Platform />

--- a/docs/vultr/quick-start/install/cli.mdx
+++ b/docs/vultr/quick-start/install/cli.mdx
@@ -9,18 +9,18 @@ image: 'https://docs.kubefirst.io/img/logo.svg'
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-import GitHubPrerequisites from '@site/docs/common/partials/github/_prerequisites.mdx';
-import GitHubClusterCreateCmd from '@site/docs/vultr/partials/github/_cluster-create.mdx';
+import GitHubPrerequisites from '../../../common/partials/github/_prerequisites.mdx';
+import GitHubClusterCreateCmd from '../../partials/github/_cluster-create.mdx';
 
-import GitLabPrerequisites from '@site/docs/common/partials/gitlab/_prerequisites.mdx';
-import GitLabClusterCreateCmd from '@site/docs/vultr/partials/gitlab/_cluster-create.mdx';
+import GitLabPrerequisites from '../../../common/partials/gitlab/_prerequisites.mdx';
+import GitLabClusterCreateCmd from '../../partials/gitlab/_cluster-create.mdx';
 
-import CommonCloudPrerequisites from '@site/docs/vultr/partials/common/_prerequisites.mdx';
-import CommonClusterConnectivity from '@site/docs/vultr/partials/common/_cluster-connectivity.mdx';
-import CommonRootCredentialsCmd from '@site/docs/vultr/partials/common/_root-credentials-cmd.mdx';
+import CommonCloudPrerequisites from '../../partials/common/_prerequisites.mdx';
+import CommonClusterConnectivity from '../../partials/common/_cluster-connectivity.mdx';
+import CommonRootCredentialsCmd from '../../partials/common/_root-credentials-cmd.mdx';
 
-import * as config from '@site/docs/constants.js';
-import styles from '@site/docs/stylesheets/tabs.module.css';
+import * as config from '../../../constants.js';
+import styles from '../../../stylesheets/tabs.module.css';
 
 export const TabLabel = ({ imgSrc, label }) => (
   <div className="git-tab">

--- a/docs/vultr/quick-start/repositories.mdx
+++ b/docs/vultr/quick-start/repositories.mdx
@@ -9,11 +9,10 @@ image: 'https://docs.kubefirst.io/img/logo.svg'
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
-import styles from '@site/docs/stylesheets/tabs.module.css';
-import ReactDom from 'react-dom';
-import * as config from '@site/docs/constants.js';
-import GitHubRepositories from '@site/docs/vultr/partials/github/_repositories.mdx';
-import GitLabRepositories from '@site/docs/vultr/partials/gitlab/_repositories.mdx';
+import styles from '../../stylesheets/tabs.module.css';
+import * as config from '../../constants.js';
+import GitHubRepositories from '../partials/github/_repositories.mdx';
+import GitLabRepositories from '../partials/gitlab/_repositories.mdx';
 
 <div
   style={{


### PR DESCRIPTION
not a problem when in v.next, but when we will create a new version from v.next, it will still use v.next instead of the new versioned_docs