### PR TITLE
make GitHub Action Syntax Check fail when vale find issues

### DIFF
--- a/.github/workflows/check-syntax.yml
+++ b/.github/workflows/check-syntax.yml
@@ -10,8 +10,17 @@ jobs:
       - name: Checkout this repository
         uses: actions/checkout@v3.5.3
 
-      - name: Validate the syntax
-        uses: errata-ai/vale-action@reviewdog
+      - name: Get latest version of Vale
+        id: lastversion
+        uses: dvershinin/lastversion-action@v0.0.3
         with:
-          fail_on_error: true
-          vale_flags: "--config=.vale.ini"
+          repository: errata-ai/vale
+
+      - name: Install Vale
+        run: |
+          wget https://github.com/errata-ai/vale/releases/download/v${{ steps.lastversion.outputs.last_version }}/vale_${{ steps.lastversion.outputs.last_version }}_Linux_64-bit.tar.gz -O vale.tar.gz
+          tar -xvzf vale.tar.gz vale
+          rm vale.tar.gz
+
+      - name: Validate the syntax
+        run: ./vale --config=.vale.ini *.md


### PR DESCRIPTION
the 'fail_on_error' option of reviewdog didn't work. See https://github.com/errata-ai/vale-action/issues/103