### PR TITLE
docs: add information about token scope

### DIFF
--- a/docs/common/git-auth.mdx
+++ b/docs/common/git-auth.mdx
@@ -10,18 +10,6 @@ import GitHubTokens from '../common/partials/github/_tokens.mdx'
 import GitLabTokens from '../common/partials/gitlab/_tokens.mdx'
 import * as config from "../constants.js"
 
-<div
-  style={{
-    display: "flex",
-    justifyContent: "flex-end",
-    alignItems: "center",
-  }}
->
-  <div>
-    <img src={config.AWS_LOGO_URL} height="50" width="120" />
-  </div>
-</div>
-
 <Tabs groupId="git_provider" defaultValue="github" queryString>
     <TabItem
       attributes={{className: styles.github}}

--- a/docs/common/partials/github/_tokens.mdx
+++ b/docs/common/partials/github/_tokens.mdx
@@ -7,6 +7,10 @@ kubefirst issue GitHub Tokens at the beginning of the installation using [GitHub
 kubefirst uses the following scopes to provision the kubefirst platform:
 ![GitHub Token Scopes](../../../img/common/github/scopes.png)
 
+:::info
+Unfortunately, those are the minimum require scopes we need for the token as we need to be able to create two Git repository, add an SSH key, crate groups (only in GitLab)... If you feel unease with that, we suggest you create a new GitHub or GitLab user for the sake of testing kubefirst.
+:::
+
 ## How to create a GitHub Token
 
 There are different ways to create a GitHub token. The easiest way is to start the kubefirst installer, and follow the screen instructions. It will guide you to issue a token with the list of scope described above.

--- a/docs/common/partials/gitlab/_tokens.mdx
+++ b/docs/common/partials/gitlab/_tokens.mdx
@@ -8,6 +8,10 @@ kubefirst uses the following scopes to provision the kubefirst platform:
 
 ![GitLab Token Scopes](../../../img/common/gitlab/scopes.png)
 
+:::info
+Unfortunately, those are the minimum require scopes we need for the token as we need to be able to create two Git repository, add an SSH key, crate groups (only in GitLab)... If you feel unease with that, we suggest you create a new GitHub or GitLab user for the sake of testing kubefirst.
+:::
+
 ## How to create a GitLab Token
 
 There are different ways to create a GitLab token. The easiest way is to start the kubefirst installer, and follow the screen instructions. It will guide you to issue a token with the list of scope described above.


### PR DESCRIPTION
Also removed the AWS logo as those are common docs between clouds now