### PR TITLE
docs: add a GitOps Catalog page to k3d

### DIFF
--- a/docs/k3d/gitops-catalog.mdx
+++ b/docs/k3d/gitops-catalog.mdx
@@ -1,0 +1,13 @@
+---
+hide_title: true
+display_sidebar: k3d
+sidebar_label: GitOps Catalog
+description: using the kubefirst gitops catalog
+keywords:
+  - aws
+image: 'https://docs.kubefirst.io/img/logo.svg'
+---
+
+import GitOpsCatalog from '../common/gitops-catalog.mdx';
+
+<GitOpsCatalog />

--- a/sidebars.js
+++ b/sidebars.js
@@ -139,6 +139,7 @@ const sidebars = {
         },
       ],
     },
+    'k3d/gitops-catalog',
     'k3d/deprovision',
     'k3d/faq',
     'k3d/credits',


### PR DESCRIPTION
In v2.30, it is also available with k3d