### PR TITLE
ci: using a TLS Node.js version to prevent setup-node issues

### DIFF
--- a/.github/workflows/check-build.yml
+++ b/.github/workflows/check-build.yml
@@ -8,17 +8,17 @@ jobs:
     steps:
 
       - name: Checkout the code
-        uses: actions/checkout@v3.5.3
+        uses: actions/checkout@v4.1.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3.7.0
+        uses: actions/setup-node@v3.8.1
         with:
-          node-version: v19.6.0
+          node-version: v18.18.0
           cache: npm
 
       - name: Cache Node.js packages
         id: cache-npm
-        uses: actions/cache@v3.3.1
+        uses: actions/cache@v3.3.2
         env:
           cache-name: cache-node-modules
         with:


### PR DESCRIPTION
See https://github.com/actions/setup-node/issues/838 for more information on the problem with v19.6.0 & non-LTS versions. I also updated to the latest version the actions/checkout, actions/setup-node & actions/cache GitHub Actions.