### PR TITLE
fix: remove note about the usage of the API.

### DIFF
--- a/docs/common/partials/common/_cli.mdx
+++ b/docs/common/partials/common/_cli.mdx
@@ -1,7 +1,3 @@
 # Install kubefirst From the CLI
 
 Using the CLI to create your cluster directly without using the [UI](./ui) is a perfect alternative for automation. The end result will be the same, a new production-ready management Kubernetes cluster, but you won't have access to the useful additional features available within the UI.
-
-:::info
-For a similar and better experience, the CLI installation process is now using our API, which will create a cluster 0 using k3d. You can safely delete it once the management cluster is created. To do so, use the `destroy` command. It will not destroy your management cluster.
-:::

--- a/versioned_docs/version-2.3/common/partials/common/_cli.mdx
+++ b/versioned_docs/version-2.3/common/partials/common/_cli.mdx
@@ -1,7 +1,3 @@
 # Install kubefirst From the CLI
 
 Using the CLI to create your cluster directly without using the [UI](./ui) is a perfect alternative for automation. The end result will be the same, a new production-ready management Kubernetes cluster, but you won't have access to the useful additional features available within the UI.
-
-:::info
-For a similar and better experience, the CLI installation process is now using our API, which will create a cluster 0 using k3d. You can safely delete it once the management cluster is created. To do so, use the `destroy` command. It will not destroy your management cluster.
-:::


### PR DESCRIPTION
It is confusing with the deprovision that should now be done with the manual steps even for cluster created directly with the CLI, and it's also clear with the updated requirements for the UI installation.