### PR TITLE
fix: remove beta on DigitalOcean in overview

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -8,7 +8,7 @@ slug: /
 
 kubefirst is a free, fully automated, and instantly operational open source platform that includes some of the most popular open source tools available in the Kubernetes space, all working together in a click.
 
-We support local, AWS, and Civo clouds, with additional clouds in beta. By running our installer in your cloud, you'll get a GitOps cloud management and application delivery ecosystem complete with automated Terraform workflows, Vault secrets management, GitLab or GitHub integrations with Argo, and a demo application that demonstrates how it all pieces together.
+By running our installer in your cloud, you'll get a GitOps cloud management and application delivery ecosystem complete with automated Terraform workflows, Vault secrets management, GitLab or GitHub integrations with Argo, and a demo application that demonstrates how it all pieces together.
 
 ![kubefirst Architecture](img/common/kubefirst/architecture-light.png#light-mode)![kubefirst Architecture](img/common/kubefirst/architecture-dark.png#dark-mode)
 
@@ -93,7 +93,7 @@ We support local, AWS, and Civo clouds, with additional clouds in beta. By runni
                title="DigitalOcean" />
             </div>
             <div className="card__body">
-            <h3>DigitalOcean (beta)</h3>
+            <h3>DigitalOcean</h3>
             <p>Whatever your vision—a SaaS app, a website, an eCommerce store—build it here using DigitalOcean's simple, cost-effective cloud hosting services.</p>
             </div>
             <div className="card__footer">

--- a/versioned_docs/version-2.3/index.mdx
+++ b/versioned_docs/version-2.3/index.mdx
@@ -8,7 +8,7 @@ slug: /
 
 kubefirst is a free, fully automated, and instantly operational open source platform that includes some of the most popular open source tools available in the Kubernetes space, all working together in a click.
 
-We support local, AWS, and Civo clouds, with additional clouds in beta. By running our installer in your cloud, you'll get a GitOps cloud management and application delivery ecosystem complete with automated Terraform workflows, Vault secrets management, GitLab or GitHub integrations with Argo, and a demo application that demonstrates how it all pieces together.
+By running our installer in your cloud, you'll get a GitOps cloud management and application delivery ecosystem complete with automated Terraform workflows, Vault secrets management, GitLab or GitHub integrations with Argo, and a demo application that demonstrates how it all pieces together.
 
 ![kubefirst Architecture](img/common/kubefirst/architecture-light.png#light-mode)![kubefirst Architecture](img/common/kubefirst/architecture-dark.png#dark-mode)
 
@@ -93,7 +93,7 @@ We support local, AWS, and Civo clouds, with additional clouds in beta. By runni
                title="DigitalOcean" />
             </div>
             <div className="card__body">
-            <h3>DigitalOcean (beta)</h3>
+            <h3>DigitalOcean</h3>
             <p>Whatever your vision—a SaaS app, a website, an eCommerce store—build it here using DigitalOcean's simple, cost-effective cloud hosting services.</p>
             </div>
             <div className="card__footer">


### PR DESCRIPTION
I also removed the list of supported clouds in the initial text, since we show them right after in a better fashion. It will make updating this page easier.