### PR TITLE
ci: update TypeSense server URL

### DIFF
--- a/.github/workflows/update-search.yml
+++ b/.github/workflows/update-search.yml
@@ -16,7 +16,7 @@ jobs:
         uses: celsiusnarhwal/typesense-scraper@v2.0.1
         with:
           api-key: ${{ secrets.TYPESENSE_ADMIN_KEY }}
-          host: typesense.mgmt.kubefirst.com
+          host: typesense.mgmt-20.kubefirst.com
           port: 443
           protocol: https
           config: typesense.docsearch.config.json


### PR DESCRIPTION
We don't use this GitHub workflow yet because of the indexing issue on our server, but it will be done once we start to use it.