### PR TITLE
feat: changing Docusaurus configurations to add trailing slashes to URLs

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -14,12 +14,9 @@ const config = {
   url: 'https://docs.kubefirst.io',
   baseUrl: process.env.BASEURL || '/',
 
-  onBrokenLinks: 'throw',
+  onBrokenLinks: 'warn',
   onBrokenMarkdownLinks: 'warn',
-
-  // Even if you don't use internalization, you can use this field to set useful
-  // metadata like html lang. For example, if your site is Chinese, you may want
-  // to replace "en" with "zh-Hans".
+  trailingSlash: true,
   i18n: {
     defaultLocale: 'en',
     locales: ['en'],

--- a/typesense.docsearch.config.json
+++ b/typesense.docsearch.config.json
@@ -1,10 +1,7 @@
 {
 	"index_name": "kubefirst",
-	"start_urls": [
-	  "https://docs.fred.dev"
-	],
 	"sitemap_urls": [
-	  "https://docs.fred.dev/sitemap.xml"
+	  "https://docs.kubefirst.io/sitemap.xml"
 	],
 	"selectors": {
 		"lvl0": "h1",


### PR DESCRIPTION
It may fix the TypeSense crawler issue with redirection.