### PR TITLE
feat: remove Docusaurus trailing slash

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -9,14 +9,10 @@ const config = {
   title: 'Kubefirst Docs',
   tagline: 'Instant Kubernetes Platforms',
   favicon: 'img/favicon.ico',
-
-  // Set the production url of your site here
   url: 'https://docs.kubefirst.io',
   baseUrl: process.env.BASEURL || '/',
-
-  onBrokenLinks: 'warn',
-  onBrokenMarkdownLinks: 'warn',
-  trailingSlash: true,
+  onBrokenLinks: 'throw',
+  onBrokenMarkdownLinks: 'throw',
   i18n: {
     defaultLocale: 'en',
     locales: ['en'],


### PR DESCRIPTION
It confirmed my hypothesis on the crawler issue on our docs. To fix it, I need to update how ngnix serve links, as using this Docusaurus option cause a lot of issues with relative path, so it's not the way to go. There is always an issue with the crawler not scraping redirections it detected, so I'll create an issue and check with TypeSense, but in the meantime, it's easy to fix it on our side with our deployment since we do not need trailing slashes on URLs.