### PR TITLE
fix: allow manage error page from docusaurus and not ngnix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,8 @@ ENV NODE_ENV production
 
 COPY --from=builder /app/build/ .
 
+COPY default.conf /etc/nginx/conf.d/
+
 EXPOSE 80
 
 ENV PORT 80

--- a/default.conf
+++ b/default.conf
@@ -1,0 +1,15 @@
+server {
+    listen       80;
+    server_name  localhost;
+
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+        try_files $uri $uri/ /index.html;
+    }
+
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+}

--- a/default.conf
+++ b/default.conf
@@ -8,6 +8,11 @@ server {
         try_files $uri $uri/ /index.html;
     }
 
+    # redirect /google/ to /gcp/ Temporal solution
+    location ~* ^/google/(.*)$ {
+        rewrite ^/google/(.*)$ /gcp/$1 last;
+    }
+
     error_page   500 502 503 504  /50x.html;
     location = /50x.html {
         root   /usr/share/nginx/html;


### PR DESCRIPTION
associated to https://github.com/kubefirst/docs/issues/721 

Actually the ngnix server try to list the directory, for that reason, when you try to access to first level, like /akamai/ you receive a 403 code:
![CleanShot 2024-06-19 at 14 06 54@2x](https://github.com/kubefirst/docs/assets/3932407/702e7bd2-b3a5-438f-aa99-b155baf9d065)

now, we'll receive a 404 managed by docusaurus:
![CleanShot 2024-06-19 at 14 09 09@2x](https://github.com/kubefirst/docs/assets/3932407/35b8070d-bf20-434c-a82e-7a1978c90619)

Another thing, I added a redirect from /google/** to /gcp/** as a temporal solution of https://github.com/kubefirst/docs/issues/721.

![CleanShot 2024-06-19 at 14 11 13](https://github.com/kubefirst/docs/assets/3932407/c3781621-e1b5-4615-91bf-b1d90e675646)


