### PR TITLE
fix: redirect digitalocean/* to do/* .

### DIFF
--- a/default.conf
+++ b/default.conf
@@ -8,6 +8,12 @@ server {
         rewrite ^/google/(.*)$ /gcp/$1 last;
     }
 
+    # redirect /digitalocean/ to /do/ for any subpath
+    location /digitalocean/ {
+        rewrite ^/digitalocean/(.*)/$ /do/$1/ last;
+        rewrite ^/digitalocean/(.*)$ /do/$1 last;
+    }
+
     location ~ ^/[^/]+/$ {
         try_files $uri /index.html;
         autoindex off;


### PR DESCRIPTION
## Description
Kubefirst CLI refrences digitalocean/* which returns 404. This redirects digitalocean path to do.

## Related Issue(s)
None

## How to test
...
