### PR TITLE
fix: show all headers in TOC

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -97,6 +97,10 @@ const config = {
           content: 'kubernetes, gitops, ci, cd, argocd, aws, civo, k3d, vultr'
         },
       ],
+      tableOfContents: {
+        minHeadingLevel: 2,
+        maxHeadingLevel: 5,
+      },
       navbar: {
         title: 'Kubefirst',
         logo: {


### PR DESCRIPTION
It was showing only H2-H3 by default.