### PR TITLE
fix: serve files from /usr/share/nginx/docs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN npm install \
 
 FROM nginx:1.25.1-alpine AS runner
 
-WORKDIR /usr/share/nginx/html
+WORKDIR /usr/share/nginx/docs
 
 ENV NODE_ENV production
 

--- a/default.conf
+++ b/default.conf
@@ -2,32 +2,28 @@ server {
     listen       80;
     server_name  localhost;
 
-    # redirect /google/ to /gcp/ for any subpath
-    location /google/ {
-        rewrite ^/google/(.*)/$ /gcp/$1/ last;
-        rewrite ^/google/(.*)$ /gcp/$1 last;
-    }
+    location /docs {
+        root   /usr/share/nginx/;
 
-    # redirect /digitalocean/ to /do/ for any subpath
-    location /digitalocean/ {
-        rewrite ^/digitalocean/(.*)/$ /do/$1/ last;
-        rewrite ^/digitalocean/(.*)$ /do/$1 last;
-    }
+        # redirect /docs/google/ to /docs/gcp/ for any subpath
+        rewrite ^/docs/google/(.*)/$ $scheme://$http_host/docs/gcp/$1/ last;
+        rewrite ^/docs/google/(.*)$ $scheme://$http_host/docs/gcp/$1 last;
 
-    location ~ ^/[^/]+/$ {
-        try_files $uri /index.html;
-        autoindex off;
-    }
+        # redirect /docs/digitalocean/ to /docs/do/ for any subpath
+        rewrite ^/docs/digitalocean/(.*)/$ $scheme://$http_host/docs/do/$1/ last;
+        rewrite ^/docs/digitalocean/(.*)$ $scheme://$http_host/docs/do/$1 last;
 
-    location / {
-        root   /usr/share/nginx/html;
         index  index.html index.htm;
-        try_files $uri $uri/ /index.html;
+        # try_files $uri $uri/ /index.html;
         autoindex off;
     }
 
+    error_page 404 = /404.html;
+    location /404.html {
+        root   /usr/share/nginx/docs;
+    }
     error_page   500 502 503 504  /50x.html;
     location = /50x.html {
-        root   /usr/share/nginx/html;
+        root   /usr/share/nginx/docs;
     }
 }


### PR DESCRIPTION
## Description
Site contents are copied to `/usr/share/nginx/docs` during docker build. Nginx config is updated to server docs from /docs. Also added rewrite from `google` and `digitalocean` to `gcp` and `do` respectively. 

## Related Issue(s)
Fixes https://github.com/konstructio/kubefirst-docs/issues/771

## How to test
There is a temporary env at https://kubefirst-development.konstruct.io/docs
