### PR TITLE
fix: wording for the GitLab group prerequisite

### DIFF
--- a/docs/akamai/partials/gitlab/_prerequisites.mdx
+++ b/docs/akamai/partials/gitlab/_prerequisites.mdx
@@ -1,7 +1,7 @@
 ### GitLab
 
 - Create or use an existing [GitLab account](https://gitlab.com).
-- Create a [GitLab group](https://docs.gitlab.com/ee/user/group/) developer permissions.
+- Create a [GitLab group](https://docs.gitlab.com/ee/user/group/) with the name you want.
 
 :::note GitLab SaaS offering has limitations that require us to use groups contrary to GitHub which can be use without an organization.
 :::

--- a/docs/civo/partials/gitlab/_prerequisites.mdx
+++ b/docs/civo/partials/gitlab/_prerequisites.mdx
@@ -1,7 +1,7 @@
 ### GitLab
 
 - Create or use an existing [GitLab account](https://gitlab.com).
-- Create a [GitLab group](https://docs.gitlab.com/ee/user/group/) developer permissions.
+- Create a [GitLab group](https://docs.gitlab.com/ee/user/group/) with the name you want.
 
 :::note GitLab SaaS offering has limitations that require us to use groups contrary to GitHub which can be use without an organization.
 :::

--- a/docs/common/partials/gitlab/_prerequisites.mdx
+++ b/docs/common/partials/gitlab/_prerequisites.mdx
@@ -1,7 +1,7 @@
 ### GitLab
 
 - Create or use an existing [GitLab account](https://gitlab.com).
-- Create a [GitLab group](https://docs.gitlab.com/ee/user/group/) developer permissions.
+- Create a [GitLab group](https://docs.gitlab.com/ee/user/group/) with the name you want.
 - A GitLab [personal access token](../../../common/git-auth.mdx) for your `kbot` account.
 
 :::note

--- a/docs/do/partials/gitlab/_prerequisites.mdx
+++ b/docs/do/partials/gitlab/_prerequisites.mdx
@@ -1,7 +1,7 @@
 ### GitLab
 
 - Create or use an existing [GitLab account](https://gitlab.com).
-- Create a [GitLab group](https://docs.gitlab.com/ee/user/group/) developer permissions.
+- Create a [GitLab group](https://docs.gitlab.com/ee/user/group/) with the name you want.
 
 :::note GitLab SaaS offering has limitations that require us to use groups contrary to GitHub which can be use without an organization.
 :::

--- a/docs/gcp/partials/gitlab/_prerequisites.mdx
+++ b/docs/gcp/partials/gitlab/_prerequisites.mdx
@@ -1,7 +1,7 @@
 ### GitLab
 
 - Create or use an existing [GitLab account](https://gitlab.com).
-- Create a [GitLab group](https://docs.gitlab.com/ee/user/group/) developer permissions.
+- Create a [GitLab group](https://docs.gitlab.com/ee/user/group/) with the name you want.
 
 :::note GitLab SaaS offering has limitations that require us to use groups contrary to GitHub which can be use without an organization.
 :::

--- a/docs/k3d/partials/gitlab/_install.mdx
+++ b/docs/k3d/partials/gitlab/_install.mdx
@@ -5,7 +5,7 @@ import CommonTerminalOutput from "../../../common/partials/common/_terminal-outp
 ### GitLab
 
 - Create or use an existing [GitLab account](https://gitlab.com).
-- Create a [GitLab group](https://docs.gitlab.com/ee/user/group/) developer permissions.
+- Create a [GitLab group](https://docs.gitlab.com/ee/user/group/) with the name you want.
 
 > GitLab SaaS offering has limitations that require us to use groups contrary to GitHub which can be use without an organization.
 

--- a/docs/k3s/partials/gitlab/_prerequisites.mdx
+++ b/docs/k3s/partials/gitlab/_prerequisites.mdx
@@ -1,7 +1,7 @@
 ### GitLab
 
 - Create or use an existing [GitLab account](https://gitlab.com).
-- Create a [GitLab group](https://docs.gitlab.com/ee/user/group/) developer permissions.
+- Create a [GitLab group](https://docs.gitlab.com/ee/user/group/) with the name you want.
 
 :::note GitLab SaaS offering has limitations that require us to use groups contrary to GitHub which can be use without an organization.
 :::

--- a/docs/vultr/partials/gitlab/_prerequisites.mdx
+++ b/docs/vultr/partials/gitlab/_prerequisites.mdx
@@ -1,7 +1,7 @@
 ### GitLab
 
 - Create or use an existing [GitLab account](https://gitlab.com).
-- Create a [GitLab group](https://docs.gitlab.com/ee/user/group/) developer permissions.
+- Create a [GitLab group](https://docs.gitlab.com/ee/user/group/) with the name you want.
 
 :::note GitLab SaaS offering has limitations that require us to use groups contrary to GitHub which can be use without an organization.
 :::

--- a/versioned_docs/version-2.6/akamai/partials/gitlab/_prerequisites.mdx
+++ b/versioned_docs/version-2.6/akamai/partials/gitlab/_prerequisites.mdx
@@ -1,7 +1,7 @@
 ### GitLab
 
 - Create or use an existing [GitLab account](https://gitlab.com).
-- Create a [GitLab group](https://docs.gitlab.com/ee/user/group/) developer permissions.
+- Create a [GitLab group](https://docs.gitlab.com/ee/user/group/) with the name you want.
 
 :::note GitLab SaaS offering has limitations that require us to use groups contrary to GitHub which can be use without an organization.
 :::

--- a/versioned_docs/version-2.6/civo/partials/gitlab/_prerequisites.mdx
+++ b/versioned_docs/version-2.6/civo/partials/gitlab/_prerequisites.mdx
@@ -1,7 +1,7 @@
 ### GitLab
 
 - Create or use an existing [GitLab account](https://gitlab.com).
-- Create a [GitLab group](https://docs.gitlab.com/ee/user/group/) developer permissions.
+- Create a [GitLab group](https://docs.gitlab.com/ee/user/group/) with the name you want.
 
 :::note GitLab SaaS offering has limitations that require us to use groups contrary to GitHub which can be use without an organization.
 :::

--- a/versioned_docs/version-2.6/common/partials/gitlab/_prerequisites.mdx
+++ b/versioned_docs/version-2.6/common/partials/gitlab/_prerequisites.mdx
@@ -1,7 +1,7 @@
 ### GitLab
 
 - Create or use an existing [GitLab account](https://gitlab.com).
-- Create a [GitLab group](https://docs.gitlab.com/ee/user/group/) developer permissions.
+- Create a [GitLab group](https://docs.gitlab.com/ee/user/group/) with the name you want.
 - A GitLab [personal access token](../../../common/git-auth.mdx) for your `kbot` account.
 
 :::note

--- a/versioned_docs/version-2.6/do/partials/gitlab/_prerequisites.mdx
+++ b/versioned_docs/version-2.6/do/partials/gitlab/_prerequisites.mdx
@@ -1,7 +1,7 @@
 ### GitLab
 
 - Create or use an existing [GitLab account](https://gitlab.com).
-- Create a [GitLab group](https://docs.gitlab.com/ee/user/group/) developer permissions.
+- Create a [GitLab group](https://docs.gitlab.com/ee/user/group/) with the name you want.
 
 :::note GitLab SaaS offering has limitations that require us to use groups contrary to GitHub which can be use without an organization.
 :::

--- a/versioned_docs/version-2.6/gcp/partials/gitlab/_prerequisites.mdx
+++ b/versioned_docs/version-2.6/gcp/partials/gitlab/_prerequisites.mdx
@@ -1,7 +1,7 @@
 ### GitLab
 
 - Create or use an existing [GitLab account](https://gitlab.com).
-- Create a [GitLab group](https://docs.gitlab.com/ee/user/group/) developer permissions.
+- Create a [GitLab group](https://docs.gitlab.com/ee/user/group/) with the name you want.
 
 :::note GitLab SaaS offering has limitations that require us to use groups contrary to GitHub which can be use without an organization.
 :::

--- a/versioned_docs/version-2.6/k3d/partials/gitlab/_install.mdx
+++ b/versioned_docs/version-2.6/k3d/partials/gitlab/_install.mdx
@@ -5,7 +5,7 @@ import CommonTerminalOutput from "../../../common/partials/common/_terminal-outp
 ### GitLab
 
 - Create or use an existing [GitLab account](https://gitlab.com).
-- Create a [GitLab group](https://docs.gitlab.com/ee/user/group/) developer permissions.
+- Create a [GitLab group](https://docs.gitlab.com/ee/user/group/) with the name you want.
 
 > GitLab SaaS offering has limitations that require us to use groups contrary to GitHub which can be use without an organization.
 

--- a/versioned_docs/version-2.6/k3s/partials/gitlab/_prerequisites.mdx
+++ b/versioned_docs/version-2.6/k3s/partials/gitlab/_prerequisites.mdx
@@ -1,7 +1,7 @@
 ### GitLab
 
 - Create or use an existing [GitLab account](https://gitlab.com).
-- Create a [GitLab group](https://docs.gitlab.com/ee/user/group/) developer permissions.
+- Create a [GitLab group](https://docs.gitlab.com/ee/user/group/) with the name you want.
 
 :::note GitLab SaaS offering has limitations that require us to use groups contrary to GitHub which can be use without an organization.
 :::

--- a/versioned_docs/version-2.6/vultr/partials/gitlab/_prerequisites.mdx
+++ b/versioned_docs/version-2.6/vultr/partials/gitlab/_prerequisites.mdx
@@ -1,7 +1,7 @@
 ### GitLab
 
 - Create or use an existing [GitLab account](https://gitlab.com).
-- Create a [GitLab group](https://docs.gitlab.com/ee/user/group/) developer permissions.
+- Create a [GitLab group](https://docs.gitlab.com/ee/user/group/) with the name you want.
 
 :::note GitLab SaaS offering has limitations that require us to use groups contrary to GitHub which can be use without an organization.
 :::


### PR DESCRIPTION
Also add information about the fact that the name can be whatever the user want to avoid confusion.