### PR TITLE
fix: update base domain to kubefirst.konstruct.io

### DIFF
--- a/.vale/Custom/substitutions.yml
+++ b/.vale/Custom/substitutions.yml
@@ -38,7 +38,7 @@ swap:
   helm: Helm
   https: HTTPS
   iam: IAM
-  '^konstruct$': Konstruct
+  konstruct: Konstruct
   # kubefirst: Kubefirst # Need to be activated again once we will fix all the lower cases.
   kubernetes: Kubernetes
   mongo: MongoDB

--- a/.vale/Custom/substitutions.yml
+++ b/.vale/Custom/substitutions.yml
@@ -38,7 +38,7 @@ swap:
   helm: Helm
   https: HTTPS
   iam: IAM
-  konstruct: Konstruct
+  '^konstruct$': Konstruct
   # kubefirst: Kubefirst # Need to be activated again once we will fix all the lower cases.
   kubernetes: Kubernetes
   mongo: MongoDB

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 # kubefirst Docs
 
-Welcome to the open source repository that powers [docs.kubefirst.io](https://docs.kubefirst.io).
+Welcome to the open source repository that powers [kubefirst.konstruct.io/docs](https://kubefirst.konstruct.io/docs).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 # kubefirst Docs
 
-Welcome to the open source repository that powers [kubefirst.konstruct.io/docs](https://kubefirst.konstruct.io/docs).
+Welcome to the open source repository that powers [the Kubefirst documentation](https://kubefirst.konstruct.io/docs).
 
 ## Contributing
 

--- a/docs/akamai/credits.mdx
+++ b/docs/akamai/credits.mdx
@@ -1,7 +1,7 @@
 ---
 title: Credits
 description: credit to all the awesome open source projects
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import CommonCredits from "../common/credits.mdx";

--- a/docs/akamai/deprovision.mdx
+++ b/docs/akamai/deprovision.mdx
@@ -5,7 +5,7 @@ sidebar_label: Deprovision
 description: how to deprovision your kubefirst platform
 keywords:
   - aws
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import Deprovision from '../common/deprovision.mdx';

--- a/docs/akamai/faq.mdx
+++ b/docs/akamai/faq.mdx
@@ -1,7 +1,7 @@
 ---
 title: FAQ
 description: frequently asked quesitons about the kubefirst platform
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import FAQ from "../common/faq.mdx";

--- a/docs/akamai/gitops-catalog.mdx
+++ b/docs/akamai/gitops-catalog.mdx
@@ -5,7 +5,7 @@ sidebar_label: GitOps Catalog
 description: using the kubefirst gitops catalog
 keywords:
   - aws
-image: 'https://docs.kubefirst.io/img/kubefirst.svg'
+image: 'https://kubefirst.konstruct.io/docs/img/kubefirst.svg'
 ---
 
 import GitOpsCatalog from '../common/gitops-catalog.mdx';

--- a/docs/akamai/overview.mdx
+++ b/docs/akamai/overview.mdx
@@ -2,7 +2,7 @@
 sidebar_label: Overview
 sidebar_position: 1
 description: an overview of kubefirst on a Akamai kubernetes cluster
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import Tabs from "@theme/Tabs";

--- a/docs/akamai/quick-start/cluster-management.mdx
+++ b/docs/akamai/quick-start/cluster-management.mdx
@@ -2,7 +2,7 @@
 title: Cluster Management
 sidebar_position: 3
 description: cluster creation and lifecycle management powered by gitops
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import CLUSTERS from "../../common/clusters.mdx";

--- a/docs/akamai/quick-start/install/cli.mdx
+++ b/docs/akamai/quick-start/install/cli.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: CLI Installer
 sidebar_position: 3
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import Tabs from "@theme/Tabs";

--- a/docs/akamai/quick-start/install/ui.mdx
+++ b/docs/akamai/quick-start/install/ui.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: UI Installer
 sidebar_position: 2
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 import UI from "../../../common/ui.mdx";
 

--- a/docs/akamai/quick-start/repositories.mdx
+++ b/docs/akamai/quick-start/repositories.mdx
@@ -2,7 +2,7 @@
 title: Repositories
 sidebar_position: 3
 description: the git repositories created by the kubefirst platform
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import REPOSITORES from "../../common/repositories.mdx";

--- a/docs/aws/credits.mdx
+++ b/docs/aws/credits.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: Credits
 description: how to destroy your kubefirst platform
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import Credits from "../common/credits.mdx";

--- a/docs/aws/deprovision.mdx
+++ b/docs/aws/deprovision.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: Deprovision
 description: how to destroy your kubefirst platform
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import Deprovision from '../common/deprovision.mdx';

--- a/docs/aws/faq.mdx
+++ b/docs/aws/faq.mdx
@@ -1,7 +1,7 @@
 ---
 title: FAQ
 description: frequently asked quesitons about the platform
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import FAQ from "../common/faq.mdx";

--- a/docs/aws/gitops-catalog.mdx
+++ b/docs/aws/gitops-catalog.mdx
@@ -5,7 +5,7 @@ sidebar_label: GitOps Catalog
 description: using the kubefirst gitops catalog
 keywords:
   - aws
-image: 'https://docs.kubefirst.io/img/kubefirst.svg'
+image: 'https://kubefirst.konstruct.io/docs/img/kubefirst.svg'
 ---
 
 import GitOpsCatalog from '../common/gitops-catalog.mdx';

--- a/docs/aws/overview.mdx
+++ b/docs/aws/overview.mdx
@@ -3,7 +3,7 @@ hide_title: true
 sidebar_label: Overview
 sidebar_position: 1
 description: an overview of the kubefirst platform
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import Tabs from "@theme/Tabs";

--- a/docs/aws/quick-start/cluster-management.mdx
+++ b/docs/aws/quick-start/cluster-management.mdx
@@ -2,7 +2,7 @@
 title: Cluster Management
 sidebar_position: 3
 description: cluster creation and lifecycle management powered by gitops
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 :::note

--- a/docs/aws/quick-start/iac-and-app-delivery.mdx
+++ b/docs/aws/quick-start/iac-and-app-delivery.mdx
@@ -3,7 +3,7 @@ hide_title: true
 sidebar_label: IAC and App Delivery
 sidebar_position: 3
 description: an overview of the kubefirst platform on aws elastic kubernetes service (EKS)
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 ## Step 1: Console UI

--- a/docs/aws/quick-start/install/cli.mdx
+++ b/docs/aws/quick-start/install/cli.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: CLI Installer
 sidebar_position: 3
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import Tabs from "@theme/Tabs";

--- a/docs/aws/quick-start/install/ui.mdx
+++ b/docs/aws/quick-start/install/ui.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: Console UI
 sidebar_position: 1
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 import UI from "../../../common/ui.mdx";
 

--- a/docs/aws/quick-start/repositories.mdx
+++ b/docs/aws/quick-start/repositories.mdx
@@ -2,7 +2,7 @@
 title: Repositories
 sidebar_position: 3
 description: the git repositories created by the kubefirst platform
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import REPOSITORES from "../../common/repositories.mdx";

--- a/docs/civo/credits.mdx
+++ b/docs/civo/credits.mdx
@@ -1,7 +1,7 @@
 ---
 title: Credits
 description: credit to all the awesome open source projects
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import CommonCredits from "../common/credits.mdx";

--- a/docs/civo/deprovision.mdx
+++ b/docs/civo/deprovision.mdx
@@ -5,7 +5,7 @@ sidebar_label: Deprovision
 description: how to deprovision your kubefirst platform
 keywords:
   - aws
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import Deprovision from '../common/deprovision.mdx';

--- a/docs/civo/faq.mdx
+++ b/docs/civo/faq.mdx
@@ -1,7 +1,7 @@
 ---
 title: FAQ
 description: frequently asked quesitons about the kubefirst platform
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import FAQ from "../common/faq.mdx";

--- a/docs/civo/gitops-catalog.mdx
+++ b/docs/civo/gitops-catalog.mdx
@@ -5,7 +5,7 @@ sidebar_label: GitOps Catalog
 description: using the kubefirst gitops catalog
 keywords:
   - aws
-image: 'https://docs.kubefirst.io/img/kubefirst.svg'
+image: 'https://kubefirst.konstruct.io/docs/img/kubefirst.svg'
 ---
 
 import GitOpsCatalog from '../common/gitops-catalog.mdx';

--- a/docs/civo/overview.mdx
+++ b/docs/civo/overview.mdx
@@ -2,7 +2,7 @@
 sidebar_label: Overview
 sidebar_position: 1
 description: an overview of kubefirst on a civo kubernetes cluster
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import Tabs from "@theme/Tabs";

--- a/docs/civo/quick-start/cluster-management.mdx
+++ b/docs/civo/quick-start/cluster-management.mdx
@@ -2,7 +2,7 @@
 title: Cluster Management
 sidebar_position: 3
 description: cluster creation and lifecycle management powered by gitops
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import CLUSTERS from "../../common/clusters.mdx";

--- a/docs/civo/quick-start/install/cli.mdx
+++ b/docs/civo/quick-start/install/cli.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: CLI Installer
 sidebar_position: 3
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import Tabs from "@theme/Tabs";

--- a/docs/civo/quick-start/install/marketplace.mdx
+++ b/docs/civo/quick-start/install/marketplace.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: Civo Marketplace
 sidebar_position: 1
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 # Install kubefirst using the Civo Marketplace

--- a/docs/civo/quick-start/install/ui.mdx
+++ b/docs/civo/quick-start/install/ui.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: UI Installer
 sidebar_position: 2
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 import UI from "../../../common/ui.mdx";
 

--- a/docs/civo/quick-start/repositories.mdx
+++ b/docs/civo/quick-start/repositories.mdx
@@ -2,7 +2,7 @@
 title: Repositories
 sidebar_position: 3
 description: the git repositories created by the kubefirst platform
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import REPOSITORES from "../../common/repositories.mdx";

--- a/docs/common/deprovision.mdx
+++ b/docs/common/deprovision.mdx
@@ -27,7 +27,7 @@ If you are coming from a cloud marketplace, and didn't use the kubefirst CLI, yo
 brew install konstructio/taps/kubefirst
 ```
 
-More information in the [installation steps from our documentation](https://docs.kubefirst.io/next/aws/quick-start/install/cli#local-prerequisites).
+More information in the [installation steps from our documentation](https://kubefirst.konstruct.io/docs/next/aws/quick-start/install/cli#local-prerequisites).
 
 ### Kubernetes CLI
 

--- a/docs/common/repositories.mdx
+++ b/docs/common/repositories.mdx
@@ -2,7 +2,7 @@
 title: Repositories
 sidebar_position: 2
 description: the git repositories created by the kubefirst platform
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import Tabs from "@theme/Tabs";

--- a/docs/do/credits.mdx
+++ b/docs/do/credits.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: Credits
 description: credit to all the awesome open source projects
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import CommonCredits from "../common/credits.mdx";

--- a/docs/do/deprovision.mdx
+++ b/docs/do/deprovision.mdx
@@ -5,7 +5,7 @@ sidebar_label: Deprovision
 description: how to deprovision your kubefirst platform
 keywords:
   - aws
-image: 'https://docs.kubefirst.io/img/kubefirst.svg'
+image: 'https://kubefirst.konstruct.io/docs/img/kubefirst.svg'
 ---
 
 import Deprovision from '../common/deprovision.mdx';

--- a/docs/do/faq.mdx
+++ b/docs/do/faq.mdx
@@ -1,7 +1,7 @@
 ---
 title: FAQ
 description: frequently asked quesitons about the kubefirst platform
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import FAQ from "../common/faq.mdx";

--- a/docs/do/gitops-catalog.mdx
+++ b/docs/do/gitops-catalog.mdx
@@ -5,7 +5,7 @@ sidebar_label: GitOps Catalog
 description: using the kubefirst gitops catalog
 keywords:
   - aws
-image: 'https://docs.kubefirst.io/img/kubefirst.svg'
+image: 'https://kubefirst.konstruct.io/docs/img/kubefirst.svg'
 ---
 
 import GitOpsCatalog from '../common/gitops-catalog.mdx';

--- a/docs/do/overview.mdx
+++ b/docs/do/overview.mdx
@@ -3,7 +3,7 @@ hide_title: true
 sidebar_label: Overview
 sidebar_position: 1
 description: an overview of kubefirst on a DigitalOcean kubernetes cluster
-image: 'https://docs.kubefirst.io/img/kubefirst.svg'
+image: 'https://kubefirst.konstruct.io/docs/img/kubefirst.svg'
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/do/quick-start/cluster-management.mdx
+++ b/docs/do/quick-start/cluster-management.mdx
@@ -2,7 +2,7 @@
 title: Cluster Management
 sidebar_position: 3
 description: cluster creation and lifecycle management powered by gitops
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 :::note

--- a/docs/do/quick-start/install/cli.mdx
+++ b/docs/do/quick-start/install/cli.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: CLI Installer
 sidebar_position: 3
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import Tabs from "@theme/Tabs";

--- a/docs/do/quick-start/install/marketplace.mdx
+++ b/docs/do/quick-start/install/marketplace.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: DigitalOcean Marketplace
 sidebar_position: 1
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 # Install kubefirst using the DigitalOcean Marketplace

--- a/docs/do/quick-start/install/ui.mdx
+++ b/docs/do/quick-start/install/ui.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: Console UI
 sidebar_position: 1
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import UI from "../../../common/ui.mdx";

--- a/docs/do/quick-start/repositories.mdx
+++ b/docs/do/quick-start/repositories.mdx
@@ -2,7 +2,7 @@
 title: Repositories
 sidebar_position: 3
 description: the git repositories created by the kubefirst platform
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import REPOSITORES from "../../common/repositories.mdx";

--- a/docs/gcp/credits.mdx
+++ b/docs/gcp/credits.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: Credits
 description: credit to all the awesome open source projects
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import CommonCredits from "../common/credits.mdx";

--- a/docs/gcp/deprovision.mdx
+++ b/docs/gcp/deprovision.mdx
@@ -5,7 +5,7 @@ sidebar_label: Deprovision
 description: how to deprovision your kubefirst platform
 keywords:
   - aws
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import Deprovision from '../common/deprovision.mdx';

--- a/docs/gcp/faq.mdx
+++ b/docs/gcp/faq.mdx
@@ -1,7 +1,7 @@
 ---
 title: FAQ
 description: frequently asked quesitons about the kubefirst platform
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import FAQ from "../common/faq.mdx";

--- a/docs/gcp/gitops-catalog.mdx
+++ b/docs/gcp/gitops-catalog.mdx
@@ -5,7 +5,7 @@ sidebar_label: GitOps Catalog
 description: using the kubefirst gitops catalog
 keywords:
   - aws
-image: 'https://docs.kubefirst.io/img/kubefirst.svg'
+image: 'https://kubefirst.konstruct.io/docs/img/kubefirst.svg'
 ---
 
 import GitOpsCatalog from '../common/gitops-catalog.mdx';

--- a/docs/gcp/overview.mdx
+++ b/docs/gcp/overview.mdx
@@ -3,7 +3,7 @@ hide_title: true
 sidebar_label: Overview
 sidebar_position: 1
 description: an overview of kubefirst on a Google Cloud kubernetes cluster
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 
 ---
 import Tabs from "@theme/Tabs";

--- a/docs/gcp/quick-start/cluster-management.mdx
+++ b/docs/gcp/quick-start/cluster-management.mdx
@@ -2,7 +2,7 @@
 title: Cluster Management
 sidebar_position: 3
 description: cluster creation and lifecycle management powered by gitops
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 :::note

--- a/docs/gcp/quick-start/install/cli.mdx
+++ b/docs/gcp/quick-start/install/cli.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: CLI Installer
 sidebar_position: 3
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import Tabs from "@theme/Tabs";

--- a/docs/gcp/quick-start/install/ui.mdx
+++ b/docs/gcp/quick-start/install/ui.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: Console UI
 sidebar_position: 1
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 import UI from "../../../common/ui.mdx";
 

--- a/docs/gcp/quick-start/repositories.mdx
+++ b/docs/gcp/quick-start/repositories.mdx
@@ -2,7 +2,7 @@
 title: Repositories
 sidebar_position: 3
 description: the git repositories created by the kubefirst platform
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import REPOSITORES from "../../common/repositories.mdx";

--- a/docs/k3d/credits.mdx
+++ b/docs/k3d/credits.mdx
@@ -3,7 +3,7 @@ hide_title: true
 sidebar_label: Credits
 sidebar_position: 4
 description: Credits for the awesome open source we use
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import Credits from "../common/credits.mdx";

--- a/docs/k3d/deprovision.mdx
+++ b/docs/k3d/deprovision.mdx
@@ -3,7 +3,7 @@ hide_title: true
 sidebar_label: Deprovision
 sidebar_position: 2
 description: how to deprovision your kubefirst platform
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 # Deprovision

--- a/docs/k3d/faq.mdx
+++ b/docs/k3d/faq.mdx
@@ -1,7 +1,7 @@
 ---
 title: FAQ
 description: frequently asked quesitons about the kubefirst platform
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import FAQ from "../common/faq.mdx";

--- a/docs/k3d/gitops-catalog.mdx
+++ b/docs/k3d/gitops-catalog.mdx
@@ -5,7 +5,7 @@ sidebar_label: GitOps Catalog
 description: using the kubefirst gitops catalog
 keywords:
   - aws
-image: 'https://docs.kubefirst.io/img/kubefirst.svg'
+image: 'https://kubefirst.konstruct.io/docs/img/kubefirst.svg'
 ---
 
 import GitOpsCatalog from '../common/gitops-catalog.mdx';

--- a/docs/k3d/overview.mdx
+++ b/docs/k3d/overview.mdx
@@ -3,7 +3,7 @@ hide_title: true
 sidebar_label: Overview
 sidebar_position: 1
 description: an overview of the kubefirst platform
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import Tabs from "@theme/Tabs";

--- a/docs/k3d/quick-start/install.mdx
+++ b/docs/k3d/quick-start/install.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: Install
 sidebar_position: 2
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import Tabs from "@theme/Tabs";

--- a/docs/k3d/quick-start/repositories.mdx
+++ b/docs/k3d/quick-start/repositories.mdx
@@ -2,7 +2,7 @@
 title: Repositories
 sidebar_position: 3
 description: the git repositories created by the kubefirst platform
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import REPOSITORES from "../../common/repositories.mdx";

--- a/docs/k3s/credits.mdx
+++ b/docs/k3s/credits.mdx
@@ -1,7 +1,7 @@
 ---
 title: Credits
 description: credit to all the awesome open source projects
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import CommonCredits from "../common/credits.mdx";

--- a/docs/k3s/deprovision.mdx
+++ b/docs/k3s/deprovision.mdx
@@ -5,7 +5,7 @@ sidebar_label: Deprovision
 description: how to deprovision your kubefirst platform
 keywords:
   - aws
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import Deprovision from '../common/deprovision.mdx';

--- a/docs/k3s/faq.mdx
+++ b/docs/k3s/faq.mdx
@@ -1,7 +1,7 @@
 ---
 title: FAQ
 description: frequently asked quesitons about the kubefirst platform
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import FAQ from "../common/faq.mdx";

--- a/docs/k3s/gitops-catalog.mdx
+++ b/docs/k3s/gitops-catalog.mdx
@@ -5,7 +5,7 @@ sidebar_label: GitOps Catalog
 description: using the kubefirst gitops catalog
 keywords:
   - aws
-image: 'https://docs.kubefirst.io/img/kubefirst.svg'
+image: 'https://kubefirst.konstruct.io/docs/img/kubefirst.svg'
 ---
 
 import GitOpsCatalog from '../common/gitops-catalog.mdx';

--- a/docs/k3s/overview.mdx
+++ b/docs/k3s/overview.mdx
@@ -2,7 +2,7 @@
 sidebar_label: Overview
 sidebar_position: 1
 description: an overview of kubefirst on a K3s kubernetes cluster
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import Tabs from "@theme/Tabs";

--- a/docs/k3s/quick-start/cluster-management.mdx
+++ b/docs/k3s/quick-start/cluster-management.mdx
@@ -2,7 +2,7 @@
 title: Cluster Management
 sidebar_position: 3
 description: cluster creation and lifecycle management powered by gitops
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import CLUSTERS from "../../common/clusters.mdx";

--- a/docs/k3s/quick-start/install/cli.mdx
+++ b/docs/k3s/quick-start/install/cli.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: CLI Installer
 sidebar_position: 3
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import Tabs from "@theme/Tabs";

--- a/docs/k3s/quick-start/install/ui.mdx
+++ b/docs/k3s/quick-start/install/ui.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: UI Installer
 sidebar_position: 2
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 <!-- markdownlint-disable MD049 -->

--- a/docs/k3s/quick-start/repositories.mdx
+++ b/docs/k3s/quick-start/repositories.mdx
@@ -2,7 +2,7 @@
 title: Repositories
 sidebar_position: 3
 description: the git repositories created by the kubefirst platform
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import REPOSITORES from "../../common/repositories.mdx";

--- a/docs/vultr/credits.mdx
+++ b/docs/vultr/credits.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: Credits
 description: credit to all the awesome open source projects
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import CommonCredits from "../common/credits.mdx";

--- a/docs/vultr/deprovision.mdx
+++ b/docs/vultr/deprovision.mdx
@@ -5,7 +5,7 @@ sidebar_label: Deprovision
 description: how to deprovision your kubefirst platform
 keywords:
   - aws
-image: 'https://docs.kubefirst.io/img/kubefirst.svg'
+image: 'https://kubefirst.konstruct.io/docs/img/kubefirst.svg'
 ---
 
 import Deprovision from '../common/deprovision.mdx';

--- a/docs/vultr/faq.mdx
+++ b/docs/vultr/faq.mdx
@@ -1,7 +1,7 @@
 ---
 title: FAQ
 description: frequently asked quesitons about the kubefirst platform
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import FAQ from "../common/faq.mdx";

--- a/docs/vultr/gitops-catalog.mdx
+++ b/docs/vultr/gitops-catalog.mdx
@@ -5,7 +5,7 @@ sidebar_label: GitOps Catalog
 description: using the kubefirst gitops catalog
 keywords:
   - aws
-image: 'https://docs.kubefirst.io/img/kubefirst.svg'
+image: 'https://kubefirst.konstruct.io/docs/img/kubefirst.svg'
 ---
 
 import GitOpsCatalog from '../common/gitops-catalog.mdx';

--- a/docs/vultr/overview.mdx
+++ b/docs/vultr/overview.mdx
@@ -3,7 +3,7 @@ hide_title: true
 sidebar_label: Overview
 sidebar_position: 1
 description: an overview of kubefirst on a Vultr kubernetes cluster
-image: 'https://docs.kubefirst.io/img/kubefirst.svg'
+image: 'https://kubefirst.konstruct.io/docs/img/kubefirst.svg'
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/vultr/quick-start/cluster-management.mdx
+++ b/docs/vultr/quick-start/cluster-management.mdx
@@ -2,7 +2,7 @@
 title: Cluster Management
 sidebar_position: 3
 description: cluster creation and lifecycle management powered by gitops
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 :::note

--- a/docs/vultr/quick-start/install/cli.mdx
+++ b/docs/vultr/quick-start/install/cli.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: CLI Installer
 sidebar_position: 3
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import Tabs from "@theme/Tabs";

--- a/docs/vultr/quick-start/install/ui.mdx
+++ b/docs/vultr/quick-start/install/ui.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: Console UI
 sidebar_position: 1
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 import UI from "../../../common/ui.mdx";
 

--- a/docs/vultr/quick-start/repositories.mdx
+++ b/docs/vultr/quick-start/repositories.mdx
@@ -2,7 +2,7 @@
 title: Repositories
 sidebar_position: 3
 description: the git repositories created by the kubefirst platform
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import REPOSITORES from "../../common/repositories.mdx";

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -102,7 +102,7 @@ const config = {
         logo: {
           alt: 'Kubefirst website',
           src: 'img/kubefirst.svg',
-          href: 'https://docs.kubefirst.io/',
+          href: 'https://kubefirst.konstruct.io/docs/',
         },
         items: [
           {

--- a/versioned_docs/version-2.1/aws/advanced/install.mdx
+++ b/versioned_docs/version-2.1/aws/advanced/install.mdx
@@ -4,7 +4,7 @@ sidebar_label: Install
 sidebar_position: 2
 custom_edit_url: https://github.com/facebook/docusaurus/edit/main/docs/api-doc-markdown.md
 description: the installation process for kubefirst cli
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import Tabs from "@theme/Tabs";

--- a/versioned_docs/version-2.1/aws/credits.mdx
+++ b/versioned_docs/version-2.1/aws/credits.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: Credits
 description: how to destroy your kubefirst platform
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import Credits from "../common/credits.mdx";

--- a/versioned_docs/version-2.1/aws/deprovision.mdx
+++ b/versioned_docs/version-2.1/aws/deprovision.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: Deprovision
 description: how to destroy your kubefirst platform
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import Deprovision from '../common/deprovision.mdx';

--- a/versioned_docs/version-2.1/aws/faq.mdx
+++ b/versioned_docs/version-2.1/aws/faq.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: FAQ
 description: frequently asked quesitons about the platform
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import FAQ from "../common/faq.mdx";

--- a/versioned_docs/version-2.1/aws/overview.mdx
+++ b/versioned_docs/version-2.1/aws/overview.mdx
@@ -3,7 +3,7 @@ hide_title: true
 sidebar_label: Overview
 sidebar_position: 1
 description: an overview of the kubefirst platform
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import Tabs from "@theme/Tabs";

--- a/versioned_docs/version-2.1/aws/quick-start/iac-and-app-delivery.mdx
+++ b/versioned_docs/version-2.1/aws/quick-start/iac-and-app-delivery.mdx
@@ -3,7 +3,7 @@ hide_title: true
 sidebar_label: IAC and App Delivery
 sidebar_position: 3
 description: an overview of the kubefirst platform on aws elastic kubernetes service (EKS)
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 ## Step 1: Console UI

--- a/versioned_docs/version-2.1/aws/quick-start/install/cli.mdx
+++ b/versioned_docs/version-2.1/aws/quick-start/install/cli.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: CLI
 sidebar_position: 2
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import Tabs from "@theme/Tabs";

--- a/versioned_docs/version-2.1/aws/quick-start/install/ui.mdx
+++ b/versioned_docs/version-2.1/aws/quick-start/install/ui.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: Console UI
 sidebar_position: 1
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 There are a few ways to install kubefirst, whether you have a cluster already or don't.

--- a/versioned_docs/version-2.1/aws/quick-start/repositories.mdx
+++ b/versioned_docs/version-2.1/aws/quick-start/repositories.mdx
@@ -3,7 +3,7 @@ hide_title: true
 sidebar_label: Repositories
 sidebar_position: 2
 description: the git repositories created by the kubefirst platform
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import Tabs from "@theme/Tabs";

--- a/versioned_docs/version-2.1/civo/credits.mdx
+++ b/versioned_docs/version-2.1/civo/credits.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: Credits
 description: credit to all the awesome open source projects
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import CommonCredits from "../common/credits.mdx";

--- a/versioned_docs/version-2.1/civo/deprovision.mdx
+++ b/versioned_docs/version-2.1/civo/deprovision.mdx
@@ -5,7 +5,7 @@ sidebar_label: Deprovision
 description: how to deprovision your kubefirst platform
 keywords:
   - aws
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import Deprovision from '../common/deprovision.mdx';

--- a/versioned_docs/version-2.1/civo/faq.mdx
+++ b/versioned_docs/version-2.1/civo/faq.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: FAQ
 description: frequently asked quesitons about the kubefirst platform
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import FAQ from "../common/faq.mdx";

--- a/versioned_docs/version-2.1/civo/overview.mdx
+++ b/versioned_docs/version-2.1/civo/overview.mdx
@@ -3,7 +3,7 @@ hide_title: true
 sidebar_label: Overview
 sidebar_position: 1
 description: an overview of kubefirst on a civo kubernetes cluster
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import Tabs from "@theme/Tabs";

--- a/versioned_docs/version-2.1/civo/quick-start/install/cli.mdx
+++ b/versioned_docs/version-2.1/civo/quick-start/install/cli.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: CLI
 sidebar_position: 2
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import Tabs from "@theme/Tabs";

--- a/versioned_docs/version-2.1/civo/quick-start/install/ui.mdx
+++ b/versioned_docs/version-2.1/civo/quick-start/install/ui.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: Console UI
 sidebar_position: 1
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 There are a few ways to install kubefirst, whether you have a cluster already or don't.

--- a/versioned_docs/version-2.1/civo/quick-start/repositories.mdx
+++ b/versioned_docs/version-2.1/civo/quick-start/repositories.mdx
@@ -3,7 +3,7 @@ hide_title: true
 sidebar_label: Repositories
 sidebar_position: 3
 description: the installation process for kubefirst cli
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import Tabs from "@theme/Tabs";

--- a/versioned_docs/version-2.1/do/upgrade.md
+++ b/versioned_docs/version-2.1/do/upgrade.md
@@ -2,4 +2,4 @@
 title: DigitalOcean
 ---
 
-DigitalOcean support was added as beta in kubefirst v2.1, but the [documentation is only starting v2.3](https://docs.kubefirst.io/next/do/overview).
+DigitalOcean support was added as beta in kubefirst v2.1, but the [documentation is only starting v2.3](https://kubefirst.konstruct.io/docs/next/do/overview).

--- a/versioned_docs/version-2.1/gcp/upgrade.md
+++ b/versioned_docs/version-2.1/gcp/upgrade.md
@@ -2,4 +2,4 @@
 title: Google Cloud
 ---
 
-Google Cloud support was added as beta in kubefirst v2.1.2, but the [documentation is only starting v2.3](https://docs.kubefirst.io/next/gcp/overview).
+Google Cloud support was added as beta in kubefirst v2.1.2, but the [documentation is only starting v2.3](https://kubefirst.konstruct.io/docs/next/gcp/overview).

--- a/versioned_docs/version-2.1/k3d/credits.mdx
+++ b/versioned_docs/version-2.1/k3d/credits.mdx
@@ -3,7 +3,7 @@ hide_title: true
 sidebar_label: Credits
 sidebar_position: 4
 description: Credits for the awesome open source we use
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import Credits from "../common/credits.mdx";

--- a/versioned_docs/version-2.1/k3d/deprovision.mdx
+++ b/versioned_docs/version-2.1/k3d/deprovision.mdx
@@ -3,7 +3,7 @@ hide_title: true
 sidebar_label: Deprovision
 sidebar_position: 2
 description: how to deprovision your kubefirst platform
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import Deprovision from '../common/deprovision.mdx';

--- a/versioned_docs/version-2.1/k3d/faq.mdx
+++ b/versioned_docs/version-2.1/k3d/faq.mdx
@@ -3,7 +3,7 @@ hide_title: true
 sidebar_label: FAQ
 sidebar_position: 3
 description: frequently asked quesitons about the kubefirst platform
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import FAQ from "../common/faq.mdx";

--- a/versioned_docs/version-2.1/k3d/overview.mdx
+++ b/versioned_docs/version-2.1/k3d/overview.mdx
@@ -3,7 +3,7 @@ hide_title: true
 sidebar_label: Overview
 sidebar_position: 1
 description: an overview of the kubefirst platform
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import Tabs from "@theme/Tabs";

--- a/versioned_docs/version-2.1/k3d/quick-start/install.mdx
+++ b/versioned_docs/version-2.1/k3d/quick-start/install.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: Install
 sidebar_position: 2
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import Tabs from "@theme/Tabs";

--- a/versioned_docs/version-2.1/k3d/quick-start/repositories.mdx
+++ b/versioned_docs/version-2.1/k3d/quick-start/repositories.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: Repositories
 sidebar_position: 3
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import Tabs from "@theme/Tabs";

--- a/versioned_docs/version-2.1/vultr/upgrade.md
+++ b/versioned_docs/version-2.1/vultr/upgrade.md
@@ -2,4 +2,4 @@
 title: Vultr
 ---
 
-Vultr support was added as beta in kubefirst v2.1, but the [documentation is only starting v2.3](https://docs.kubefirst.io/next/vultr/overview).
+Vultr support was added as beta in kubefirst v2.1, but the [documentation is only starting v2.3](https://kubefirst.konstruct.io/docs/next/vultr/overview).

--- a/versioned_docs/version-2.2/aws/advanced/install.mdx
+++ b/versioned_docs/version-2.2/aws/advanced/install.mdx
@@ -4,7 +4,7 @@ sidebar_label: Install
 sidebar_position: 2
 custom_edit_url: https://github.com/facebook/docusaurus/edit/main/docs/api-doc-markdown.md
 description: the installation process for kubefirst cli
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import Tabs from "@theme/Tabs";

--- a/versioned_docs/version-2.2/aws/credits.mdx
+++ b/versioned_docs/version-2.2/aws/credits.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: Credits
 description: how to destroy your kubefirst platform
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import Credits from "../common/credits.mdx";

--- a/versioned_docs/version-2.2/aws/deprovision.mdx
+++ b/versioned_docs/version-2.2/aws/deprovision.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: Deprovision
 description: how to destroy your kubefirst platform
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import Deprovision from '../common/deprovision.mdx';

--- a/versioned_docs/version-2.2/aws/faq.mdx
+++ b/versioned_docs/version-2.2/aws/faq.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: FAQ
 description: frequently asked quesitons about the platform
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import FAQ from "../common/faq.mdx";

--- a/versioned_docs/version-2.2/aws/gitops-catalog.mdx
+++ b/versioned_docs/version-2.2/aws/gitops-catalog.mdx
@@ -5,7 +5,7 @@ sidebar_label: GitOps Catalog
 description: using the kubefirst gitops catalog
 keywords:
   - aws
-image: 'https://docs.kubefirst.io/img/logo.svg'
+image: 'https://kubefirst.konstruct.io/docs/img/logo.svg'
 ---
 
 import GitOpsCatalog from '../common/gitops-catalog.mdx';

--- a/versioned_docs/version-2.2/aws/overview.mdx
+++ b/versioned_docs/version-2.2/aws/overview.mdx
@@ -3,7 +3,7 @@ hide_title: true
 sidebar_label: Overview
 sidebar_position: 1
 description: an overview of the kubefirst platform
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import Tabs from "@theme/Tabs";

--- a/versioned_docs/version-2.2/aws/quick-start/iac-and-app-delivery.mdx
+++ b/versioned_docs/version-2.2/aws/quick-start/iac-and-app-delivery.mdx
@@ -3,7 +3,7 @@ hide_title: true
 sidebar_label: IAC and App Delivery
 sidebar_position: 3
 description: an overview of the kubefirst platform on aws elastic kubernetes service (EKS)
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 ## Step 1: Console UI

--- a/versioned_docs/version-2.2/aws/quick-start/install/cli.mdx
+++ b/versioned_docs/version-2.2/aws/quick-start/install/cli.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: CLI
 sidebar_position: 2
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import Tabs from "@theme/Tabs";

--- a/versioned_docs/version-2.2/aws/quick-start/install/ui.mdx
+++ b/versioned_docs/version-2.2/aws/quick-start/install/ui.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: Console UI
 sidebar_position: 1
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 There are a few ways to install kubefirst, whether you have a cluster already or don't.

--- a/versioned_docs/version-2.2/aws/quick-start/repositories.mdx
+++ b/versioned_docs/version-2.2/aws/quick-start/repositories.mdx
@@ -3,7 +3,7 @@ hide_title: true
 sidebar_label: Repositories
 sidebar_position: 2
 description: the git repositories created by the kubefirst platform
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import Tabs from "@theme/Tabs";

--- a/versioned_docs/version-2.2/civo/credits.mdx
+++ b/versioned_docs/version-2.2/civo/credits.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: Credits
 description: credit to all the awesome open source projects
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import CommonCredits from "../common/credits.mdx";

--- a/versioned_docs/version-2.2/civo/deprovision.mdx
+++ b/versioned_docs/version-2.2/civo/deprovision.mdx
@@ -5,7 +5,7 @@ sidebar_label: Deprovision
 description: how to deprovision your kubefirst platform
 keywords:
   - aws
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import Deprovision from '../common/deprovision.mdx';

--- a/versioned_docs/version-2.2/civo/faq.mdx
+++ b/versioned_docs/version-2.2/civo/faq.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: FAQ
 description: frequently asked quesitons about the kubefirst platform
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import FAQ from "../common/faq.mdx";

--- a/versioned_docs/version-2.2/civo/gitops-catalog.mdx
+++ b/versioned_docs/version-2.2/civo/gitops-catalog.mdx
@@ -5,7 +5,7 @@ sidebar_label: GitOps Catalog
 description: using the kubefirst gitops catalog
 keywords:
   - aws
-image: 'https://docs.kubefirst.io/img/logo.svg'
+image: 'https://kubefirst.konstruct.io/docs/img/logo.svg'
 ---
 
 import GitOpsCatalog from '../common/gitops-catalog.mdx';

--- a/versioned_docs/version-2.2/civo/overview.mdx
+++ b/versioned_docs/version-2.2/civo/overview.mdx
@@ -3,7 +3,7 @@ hide_title: true
 sidebar_label: Overview
 sidebar_position: 1
 description: an overview of kubefirst on a civo kubernetes cluster
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import Tabs from "@theme/Tabs";

--- a/versioned_docs/version-2.2/civo/quick-start/install/cli.mdx
+++ b/versioned_docs/version-2.2/civo/quick-start/install/cli.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: CLI Installer
 sidebar_position: 3
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import Tabs from "@theme/Tabs";

--- a/versioned_docs/version-2.2/civo/quick-start/install/marketplace.mdx
+++ b/versioned_docs/version-2.2/civo/quick-start/install/marketplace.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: Civo Marketplace Installer
 sidebar_position: 1
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 You can create a temporary kubefirst installer cluster through the Civo Kubernetes marketplace, and use it to create your kubefirst management cluster.

--- a/versioned_docs/version-2.2/civo/quick-start/install/ui.mdx
+++ b/versioned_docs/version-2.2/civo/quick-start/install/ui.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: UI Installer
 sidebar_position: 2
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 There are a few ways to install kubefirst, whether you have a cluster already or don't.

--- a/versioned_docs/version-2.2/civo/quick-start/repositories.mdx
+++ b/versioned_docs/version-2.2/civo/quick-start/repositories.mdx
@@ -3,7 +3,7 @@ hide_title: true
 sidebar_label: Repositories
 sidebar_position: 3
 description: the installation process for kubefirst cli
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";

--- a/versioned_docs/version-2.2/do/credits.mdx
+++ b/versioned_docs/version-2.2/do/credits.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: Credits
 description: credit to all the awesome open source projects
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import CommonCredits from "../common/credits.mdx";

--- a/versioned_docs/version-2.2/do/deprovision.mdx
+++ b/versioned_docs/version-2.2/do/deprovision.mdx
@@ -5,7 +5,7 @@ sidebar_label: Deprovision
 description: how to deprovision your kubefirst platform
 keywords:
   - aws
-image: 'https://docs.kubefirst.io/img/logo.svg'
+image: 'https://kubefirst.konstruct.io/docs/img/logo.svg'
 ---
 
 import Deprovision from '../common/deprovision.mdx';

--- a/versioned_docs/version-2.2/do/faq.mdx
+++ b/versioned_docs/version-2.2/do/faq.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: FAQ
 description: frequently asked quesitons about the kubefirst platform
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import FAQ from "../common/faq.mdx";

--- a/versioned_docs/version-2.2/do/gitops-catalog.mdx
+++ b/versioned_docs/version-2.2/do/gitops-catalog.mdx
@@ -5,7 +5,7 @@ sidebar_label: GitOps Catalog
 description: using the kubefirst gitops catalog
 keywords:
   - aws
-image: 'https://docs.kubefirst.io/img/logo.svg'
+image: 'https://kubefirst.konstruct.io/docs/img/logo.svg'
 ---
 
 import GitOpsCatalog from '../common/gitops-catalog.mdx';

--- a/versioned_docs/version-2.2/do/overview.mdx
+++ b/versioned_docs/version-2.2/do/overview.mdx
@@ -3,7 +3,7 @@ hide_title: true
 sidebar_label: Overview
 sidebar_position: 1
 description: an overview of kubefirst on a DigitalOcean kubernetes cluster
-image: 'https://docs.kubefirst.io/img/logo.svg'
+image: 'https://kubefirst.konstruct.io/docs/img/logo.svg'
 ---
 
 import Tabs from '@theme/Tabs';

--- a/versioned_docs/version-2.2/do/quick-start/install/cli.mdx
+++ b/versioned_docs/version-2.2/do/quick-start/install/cli.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: CLI
 sidebar_position: 2
-image: 'https://docs.kubefirst.io/img/logo.svg'
+image: 'https://kubefirst.konstruct.io/docs/img/logo.svg'
 ---
 
 import Tabs from '@theme/Tabs';

--- a/versioned_docs/version-2.2/do/quick-start/install/ui.mdx
+++ b/versioned_docs/version-2.2/do/quick-start/install/ui.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: Console UI
 sidebar_position: 1
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 There are a few ways to install kubefirst, whether you have a cluster already or don't.

--- a/versioned_docs/version-2.2/do/quick-start/repositories.mdx
+++ b/versioned_docs/version-2.2/do/quick-start/repositories.mdx
@@ -3,7 +3,7 @@ hide_title: true
 sidebar_label: Repositories
 sidebar_position: 3
 description: the installation process for kubefirst cli
-image: 'https://docs.kubefirst.io/img/logo.svg'
+image: 'https://kubefirst.konstruct.io/docs/img/logo.svg'
 ---
 
 import Tabs from '@theme/Tabs';

--- a/versioned_docs/version-2.2/gcp/credits.mdx
+++ b/versioned_docs/version-2.2/gcp/credits.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: Credits
 description: credit to all the awesome open source projects
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import CommonCredits from "../common/credits.mdx";

--- a/versioned_docs/version-2.2/gcp/deprovision.mdx
+++ b/versioned_docs/version-2.2/gcp/deprovision.mdx
@@ -5,7 +5,7 @@ sidebar_label: Deprovision
 description: how to deprovision your kubefirst platform
 keywords:
   - aws
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import Deprovision from '../common/deprovision.mdx';

--- a/versioned_docs/version-2.2/gcp/faq.mdx
+++ b/versioned_docs/version-2.2/gcp/faq.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: FAQ
 description: frequently asked quesitons about the kubefirst platform
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import FAQ from "../common/faq.mdx";

--- a/versioned_docs/version-2.2/gcp/gitops-catalog.mdx
+++ b/versioned_docs/version-2.2/gcp/gitops-catalog.mdx
@@ -5,7 +5,7 @@ sidebar_label: GitOps Catalog
 description: using the kubefirst gitops catalog
 keywords:
   - aws
-image: 'https://docs.kubefirst.io/img/logo.svg'
+image: 'https://kubefirst.konstruct.io/docs/img/logo.svg'
 ---
 
 import GitOpsCatalog from '../common/gitops-catalog.mdx';

--- a/versioned_docs/version-2.2/gcp/overview.mdx
+++ b/versioned_docs/version-2.2/gcp/overview.mdx
@@ -3,7 +3,7 @@ hide_title: true
 sidebar_label: Overview
 sidebar_position: 1
 description: an overview of kubefirst on a Google Cloud kubernetes cluster
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 
 ---
 import Tabs from "@theme/Tabs";

--- a/versioned_docs/version-2.2/gcp/quick-start/install/cli.mdx
+++ b/versioned_docs/version-2.2/gcp/quick-start/install/cli.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: CLI
 sidebar_position: 2
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import Tabs from "@theme/Tabs";

--- a/versioned_docs/version-2.2/gcp/quick-start/install/ui.mdx
+++ b/versioned_docs/version-2.2/gcp/quick-start/install/ui.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: Console UI
 sidebar_position: 1
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 There are a few ways to install kubefirst, whether you have a cluster already or don't.

--- a/versioned_docs/version-2.2/gcp/quick-start/repositories.mdx
+++ b/versioned_docs/version-2.2/gcp/quick-start/repositories.mdx
@@ -3,7 +3,7 @@ hide_title: true
 sidebar_label: Repositories
 sidebar_position: 3
 description: the installation process for kubefirst cli
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import Tabs from "@theme/Tabs";

--- a/versioned_docs/version-2.2/k3d/credits.mdx
+++ b/versioned_docs/version-2.2/k3d/credits.mdx
@@ -3,7 +3,7 @@ hide_title: true
 sidebar_label: Credits
 sidebar_position: 4
 description: Credits for the awesome open source we use
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import Credits from "../common/credits.mdx";

--- a/versioned_docs/version-2.2/k3d/deprovision.mdx
+++ b/versioned_docs/version-2.2/k3d/deprovision.mdx
@@ -3,7 +3,7 @@ hide_title: true
 sidebar_label: Deprovision
 sidebar_position: 2
 description: how to deprovision your kubefirst platform
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import Deprovision from '../common/deprovision.mdx';

--- a/versioned_docs/version-2.2/k3d/faq.mdx
+++ b/versioned_docs/version-2.2/k3d/faq.mdx
@@ -3,7 +3,7 @@ hide_title: true
 sidebar_label: FAQ
 sidebar_position: 3
 description: frequently asked quesitons about the kubefirst platform
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import FAQ from "../common/faq.mdx";

--- a/versioned_docs/version-2.2/k3d/overview.mdx
+++ b/versioned_docs/version-2.2/k3d/overview.mdx
@@ -3,7 +3,7 @@ hide_title: true
 sidebar_label: Overview
 sidebar_position: 1
 description: an overview of the kubefirst platform
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import Tabs from "@theme/Tabs";

--- a/versioned_docs/version-2.2/k3d/quick-start/install.mdx
+++ b/versioned_docs/version-2.2/k3d/quick-start/install.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: Install
 sidebar_position: 2
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";

--- a/versioned_docs/version-2.2/k3d/quick-start/repositories.mdx
+++ b/versioned_docs/version-2.2/k3d/quick-start/repositories.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: Repositories
 sidebar_position: 3
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";

--- a/versioned_docs/version-2.2/vultr/credits.mdx
+++ b/versioned_docs/version-2.2/vultr/credits.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: Credits
 description: credit to all the awesome open source projects
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import CommonCredits from "../common/credits.mdx";

--- a/versioned_docs/version-2.2/vultr/deprovision.mdx
+++ b/versioned_docs/version-2.2/vultr/deprovision.mdx
@@ -5,7 +5,7 @@ sidebar_label: Deprovision
 description: how to deprovision your kubefirst platform
 keywords:
   - aws
-image: 'https://docs.kubefirst.io/img/logo.svg'
+image: 'https://kubefirst.konstruct.io/docs/img/logo.svg'
 ---
 
 import Deprovision from '../common/deprovision.mdx';

--- a/versioned_docs/version-2.2/vultr/faq.mdx
+++ b/versioned_docs/version-2.2/vultr/faq.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: FAQ
 description: frequently asked quesitons about the kubefirst platform
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import FAQ from "../common/faq.mdx";

--- a/versioned_docs/version-2.2/vultr/gitops-catalog.mdx
+++ b/versioned_docs/version-2.2/vultr/gitops-catalog.mdx
@@ -5,7 +5,7 @@ sidebar_label: GitOps Catalog
 description: using the kubefirst gitops catalog
 keywords:
   - aws
-image: 'https://docs.kubefirst.io/img/logo.svg'
+image: 'https://kubefirst.konstruct.io/docs/img/logo.svg'
 ---
 
 import GitOpsCatalog from '../common/gitops-catalog.mdx';

--- a/versioned_docs/version-2.2/vultr/overview.mdx
+++ b/versioned_docs/version-2.2/vultr/overview.mdx
@@ -3,7 +3,7 @@ hide_title: true
 sidebar_label: Overview
 sidebar_position: 1
 description: an overview of kubefirst on a Vultr kubernetes cluster
-image: 'https://docs.kubefirst.io/img/logo.svg'
+image: 'https://kubefirst.konstruct.io/docs/img/logo.svg'
 ---
 
 import Tabs from '@theme/Tabs';

--- a/versioned_docs/version-2.2/vultr/quick-start/install/cli.mdx
+++ b/versioned_docs/version-2.2/vultr/quick-start/install/cli.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: CLI
 sidebar_position: 2
-image: 'https://docs.kubefirst.io/img/logo.svg'
+image: 'https://kubefirst.konstruct.io/docs/img/logo.svg'
 ---
 
 import Tabs from '@theme/Tabs';

--- a/versioned_docs/version-2.2/vultr/quick-start/install/ui.mdx
+++ b/versioned_docs/version-2.2/vultr/quick-start/install/ui.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: Console UI
 sidebar_position: 1
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 There are a few ways to install kubefirst, whether you have a cluster already or don't.

--- a/versioned_docs/version-2.2/vultr/quick-start/repositories.mdx
+++ b/versioned_docs/version-2.2/vultr/quick-start/repositories.mdx
@@ -3,7 +3,7 @@ hide_title: true
 sidebar_label: Repositories
 sidebar_position: 3
 description: the installation process for kubefirst cli
-image: 'https://docs.kubefirst.io/img/logo.svg'
+image: 'https://kubefirst.konstruct.io/docs/img/logo.svg'
 ---
 
 import Tabs from '@theme/Tabs';

--- a/versioned_docs/version-2.3/aws/credits.mdx
+++ b/versioned_docs/version-2.3/aws/credits.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: Credits
 description: how to destroy your kubefirst platform
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import Credits from "../common/credits.mdx";

--- a/versioned_docs/version-2.3/aws/deprovision.mdx
+++ b/versioned_docs/version-2.3/aws/deprovision.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: Deprovision
 description: how to destroy your kubefirst platform
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import Deprovision from '../common/deprovision.mdx';

--- a/versioned_docs/version-2.3/aws/faq.mdx
+++ b/versioned_docs/version-2.3/aws/faq.mdx
@@ -1,7 +1,7 @@
 ---
 title: FAQ
 description: frequently asked quesitons about the platform
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import FAQ from "../common/faq.mdx";

--- a/versioned_docs/version-2.3/aws/gitops-catalog.mdx
+++ b/versioned_docs/version-2.3/aws/gitops-catalog.mdx
@@ -5,7 +5,7 @@ sidebar_label: GitOps Catalog
 description: using the kubefirst gitops catalog
 keywords:
   - aws
-image: 'https://docs.kubefirst.io/img/logo.svg'
+image: 'https://kubefirst.konstruct.io/docs/img/logo.svg'
 ---
 
 import GitOpsCatalog from '../common/gitops-catalog.mdx';

--- a/versioned_docs/version-2.3/aws/overview.mdx
+++ b/versioned_docs/version-2.3/aws/overview.mdx
@@ -3,7 +3,7 @@ hide_title: true
 sidebar_label: Overview
 sidebar_position: 1
 description: an overview of the kubefirst platform
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import Tabs from "@theme/Tabs";

--- a/versioned_docs/version-2.3/aws/quick-start/cluster-management.mdx
+++ b/versioned_docs/version-2.3/aws/quick-start/cluster-management.mdx
@@ -2,7 +2,7 @@
 title: Cluster Management
 sidebar_position: 3
 description: cluster creation and lifecycle management powered by gitops
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 :::note

--- a/versioned_docs/version-2.3/aws/quick-start/iac-and-app-delivery.mdx
+++ b/versioned_docs/version-2.3/aws/quick-start/iac-and-app-delivery.mdx
@@ -3,7 +3,7 @@ hide_title: true
 sidebar_label: IAC and App Delivery
 sidebar_position: 3
 description: an overview of the kubefirst platform on aws elastic kubernetes service (EKS)
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 ## Step 1: Console UI

--- a/versioned_docs/version-2.3/aws/quick-start/install/cli.mdx
+++ b/versioned_docs/version-2.3/aws/quick-start/install/cli.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: CLI Installer
 sidebar_position: 3
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import Tabs from "@theme/Tabs";

--- a/versioned_docs/version-2.3/aws/quick-start/install/ui.mdx
+++ b/versioned_docs/version-2.3/aws/quick-start/install/ui.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: Console UI
 sidebar_position: 1
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 import UI from "../../../common/ui.mdx";
 

--- a/versioned_docs/version-2.3/aws/quick-start/repositories.mdx
+++ b/versioned_docs/version-2.3/aws/quick-start/repositories.mdx
@@ -2,7 +2,7 @@
 title: Repositories
 sidebar_position: 3
 description: the git repositories created by the kubefirst platform
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import REPOSITORES from "../../common/repositories.mdx";

--- a/versioned_docs/version-2.3/civo/credits.mdx
+++ b/versioned_docs/version-2.3/civo/credits.mdx
@@ -1,7 +1,7 @@
 ---
 title: Credits
 description: credit to all the awesome open source projects
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import CommonCredits from "../common/credits.mdx";

--- a/versioned_docs/version-2.3/civo/deprovision.mdx
+++ b/versioned_docs/version-2.3/civo/deprovision.mdx
@@ -5,7 +5,7 @@ sidebar_label: Deprovision
 description: how to deprovision your kubefirst platform
 keywords:
   - aws
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import Deprovision from '../common/deprovision.mdx';

--- a/versioned_docs/version-2.3/civo/faq.mdx
+++ b/versioned_docs/version-2.3/civo/faq.mdx
@@ -1,7 +1,7 @@
 ---
 title: FAQ
 description: frequently asked quesitons about the kubefirst platform
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import FAQ from "../common/faq.mdx";

--- a/versioned_docs/version-2.3/civo/gitops-catalog.mdx
+++ b/versioned_docs/version-2.3/civo/gitops-catalog.mdx
@@ -5,7 +5,7 @@ sidebar_label: GitOps Catalog
 description: using the kubefirst gitops catalog
 keywords:
   - aws
-image: 'https://docs.kubefirst.io/img/logo.svg'
+image: 'https://kubefirst.konstruct.io/docs/img/logo.svg'
 ---
 
 import GitOpsCatalog from '../common/gitops-catalog.mdx';

--- a/versioned_docs/version-2.3/civo/overview.mdx
+++ b/versioned_docs/version-2.3/civo/overview.mdx
@@ -2,7 +2,7 @@
 sidebar_label: Overview
 sidebar_position: 1
 description: an overview of kubefirst on a civo kubernetes cluster
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import Tabs from "@theme/Tabs";

--- a/versioned_docs/version-2.3/civo/quick-start/cluster-management.mdx
+++ b/versioned_docs/version-2.3/civo/quick-start/cluster-management.mdx
@@ -2,7 +2,7 @@
 title: Cluster Management
 sidebar_position: 3
 description: cluster creation and lifecycle management powered by gitops
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import CLUSTERS from "../../common/clusters.mdx";

--- a/versioned_docs/version-2.3/civo/quick-start/install/cli.mdx
+++ b/versioned_docs/version-2.3/civo/quick-start/install/cli.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: CLI Installer
 sidebar_position: 3
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import Tabs from "@theme/Tabs";

--- a/versioned_docs/version-2.3/civo/quick-start/install/marketplace.mdx
+++ b/versioned_docs/version-2.3/civo/quick-start/install/marketplace.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: Civo Marketplace
 sidebar_position: 1
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 # Install kubefirst using the Civo Marketplace

--- a/versioned_docs/version-2.3/civo/quick-start/install/ui.mdx
+++ b/versioned_docs/version-2.3/civo/quick-start/install/ui.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: UI Installer
 sidebar_position: 2
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 import UI from "../../../common/ui.mdx";
 

--- a/versioned_docs/version-2.3/civo/quick-start/repositories.mdx
+++ b/versioned_docs/version-2.3/civo/quick-start/repositories.mdx
@@ -2,7 +2,7 @@
 title: Repositories
 sidebar_position: 3
 description: the git repositories created by the kubefirst platform
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import REPOSITORES from "../../common/repositories.mdx";

--- a/versioned_docs/version-2.3/common/deprovision.mdx
+++ b/versioned_docs/version-2.3/common/deprovision.mdx
@@ -25,7 +25,7 @@ If you are coming from a cloud marketplace, and didn't use the kubefirst CLI, yo
 brew install konstructio/taps/kubefirst
 ```
 
-More information in the [installation steps from our documentation](https://docs.kubefirst.io/next/aws/quick-start/install/cli#local-prerequisites).
+More information in the [installation steps from our documentation](https://kubefirst.konstruct.io/docs/next/aws/quick-start/install/cli#local-prerequisites).
 
 ### Kubernetes CLI
 

--- a/versioned_docs/version-2.3/common/repositories.mdx
+++ b/versioned_docs/version-2.3/common/repositories.mdx
@@ -2,7 +2,7 @@
 title: Repositories
 sidebar_position: 2
 description: the git repositories created by the kubefirst platform
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import Tabs from "@theme/Tabs";

--- a/versioned_docs/version-2.3/do/credits.mdx
+++ b/versioned_docs/version-2.3/do/credits.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: Credits
 description: credit to all the awesome open source projects
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import CommonCredits from "../common/credits.mdx";

--- a/versioned_docs/version-2.3/do/deprovision.mdx
+++ b/versioned_docs/version-2.3/do/deprovision.mdx
@@ -5,7 +5,7 @@ sidebar_label: Deprovision
 description: how to deprovision your kubefirst platform
 keywords:
   - aws
-image: 'https://docs.kubefirst.io/img/logo.svg'
+image: 'https://kubefirst.konstruct.io/docs/img/logo.svg'
 ---
 
 import Deprovision from '../common/deprovision.mdx';

--- a/versioned_docs/version-2.3/do/faq.mdx
+++ b/versioned_docs/version-2.3/do/faq.mdx
@@ -1,7 +1,7 @@
 ---
 title: FAQ
 description: frequently asked quesitons about the kubefirst platform
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import FAQ from "../common/faq.mdx";

--- a/versioned_docs/version-2.3/do/gitops-catalog.mdx
+++ b/versioned_docs/version-2.3/do/gitops-catalog.mdx
@@ -5,7 +5,7 @@ sidebar_label: GitOps Catalog
 description: using the kubefirst gitops catalog
 keywords:
   - aws
-image: 'https://docs.kubefirst.io/img/logo.svg'
+image: 'https://kubefirst.konstruct.io/docs/img/logo.svg'
 ---
 
 import GitOpsCatalog from '../common/gitops-catalog.mdx';

--- a/versioned_docs/version-2.3/do/overview.mdx
+++ b/versioned_docs/version-2.3/do/overview.mdx
@@ -3,7 +3,7 @@ hide_title: true
 sidebar_label: Overview
 sidebar_position: 1
 description: an overview of kubefirst on a DigitalOcean kubernetes cluster
-image: 'https://docs.kubefirst.io/img/logo.svg'
+image: 'https://kubefirst.konstruct.io/docs/img/logo.svg'
 ---
 
 import Tabs from '@theme/Tabs';

--- a/versioned_docs/version-2.3/do/quick-start/cluster-management.mdx
+++ b/versioned_docs/version-2.3/do/quick-start/cluster-management.mdx
@@ -2,7 +2,7 @@
 title: Cluster Management
 sidebar_position: 3
 description: cluster creation and lifecycle management powered by gitops
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 :::note

--- a/versioned_docs/version-2.3/do/quick-start/install/cli.mdx
+++ b/versioned_docs/version-2.3/do/quick-start/install/cli.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: CLI Installer
 sidebar_position: 3
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import Tabs from "@theme/Tabs";

--- a/versioned_docs/version-2.3/do/quick-start/install/marketplace.mdx
+++ b/versioned_docs/version-2.3/do/quick-start/install/marketplace.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: DigitalOcean Marketplace
 sidebar_position: 1
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 # Install kubefirst using the DigitalOcean Marketplace

--- a/versioned_docs/version-2.3/do/quick-start/install/ui.mdx
+++ b/versioned_docs/version-2.3/do/quick-start/install/ui.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: Console UI
 sidebar_position: 1
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import UI from "../../../common/ui.mdx";

--- a/versioned_docs/version-2.3/do/quick-start/repositories.mdx
+++ b/versioned_docs/version-2.3/do/quick-start/repositories.mdx
@@ -2,7 +2,7 @@
 title: Repositories
 sidebar_position: 3
 description: the git repositories created by the kubefirst platform
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import REPOSITORES from "../../common/repositories.mdx";

--- a/versioned_docs/version-2.3/gcp/credits.mdx
+++ b/versioned_docs/version-2.3/gcp/credits.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: Credits
 description: credit to all the awesome open source projects
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import CommonCredits from "../common/credits.mdx";

--- a/versioned_docs/version-2.3/gcp/deprovision.mdx
+++ b/versioned_docs/version-2.3/gcp/deprovision.mdx
@@ -5,7 +5,7 @@ sidebar_label: Deprovision
 description: how to deprovision your kubefirst platform
 keywords:
   - aws
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import Deprovision from '../common/deprovision.mdx';

--- a/versioned_docs/version-2.3/gcp/faq.mdx
+++ b/versioned_docs/version-2.3/gcp/faq.mdx
@@ -1,7 +1,7 @@
 ---
 title: FAQ
 description: frequently asked quesitons about the kubefirst platform
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import FAQ from "../common/faq.mdx";

--- a/versioned_docs/version-2.3/gcp/gitops-catalog.mdx
+++ b/versioned_docs/version-2.3/gcp/gitops-catalog.mdx
@@ -5,7 +5,7 @@ sidebar_label: GitOps Catalog
 description: using the kubefirst gitops catalog
 keywords:
   - aws
-image: 'https://docs.kubefirst.io/img/logo.svg'
+image: 'https://kubefirst.konstruct.io/docs/img/logo.svg'
 ---
 
 import GitOpsCatalog from '../common/gitops-catalog.mdx';

--- a/versioned_docs/version-2.3/gcp/overview.mdx
+++ b/versioned_docs/version-2.3/gcp/overview.mdx
@@ -3,7 +3,7 @@ hide_title: true
 sidebar_label: Overview
 sidebar_position: 1
 description: an overview of kubefirst on a Google Cloud kubernetes cluster
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 
 ---
 import Tabs from "@theme/Tabs";

--- a/versioned_docs/version-2.3/gcp/quick-start/cluster-management.mdx
+++ b/versioned_docs/version-2.3/gcp/quick-start/cluster-management.mdx
@@ -2,7 +2,7 @@
 title: Cluster Management
 sidebar_position: 3
 description: cluster creation and lifecycle management powered by gitops
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 :::note

--- a/versioned_docs/version-2.3/gcp/quick-start/install/cli.mdx
+++ b/versioned_docs/version-2.3/gcp/quick-start/install/cli.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: CLI Installer
 sidebar_position: 3
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import Tabs from "@theme/Tabs";

--- a/versioned_docs/version-2.3/gcp/quick-start/install/ui.mdx
+++ b/versioned_docs/version-2.3/gcp/quick-start/install/ui.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: Console UI
 sidebar_position: 1
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 import UI from "../../../common/ui.mdx";
 

--- a/versioned_docs/version-2.3/gcp/quick-start/repositories.mdx
+++ b/versioned_docs/version-2.3/gcp/quick-start/repositories.mdx
@@ -2,7 +2,7 @@
 title: Repositories
 sidebar_position: 3
 description: the git repositories created by the kubefirst platform
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import REPOSITORES from "../../common/repositories.mdx";

--- a/versioned_docs/version-2.3/k3d/credits.mdx
+++ b/versioned_docs/version-2.3/k3d/credits.mdx
@@ -3,7 +3,7 @@ hide_title: true
 sidebar_label: Credits
 sidebar_position: 4
 description: Credits for the awesome open source we use
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import Credits from "../common/credits.mdx";

--- a/versioned_docs/version-2.3/k3d/deprovision.mdx
+++ b/versioned_docs/version-2.3/k3d/deprovision.mdx
@@ -3,7 +3,7 @@ hide_title: true
 sidebar_label: Deprovision
 sidebar_position: 2
 description: how to deprovision your kubefirst platform
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 # Deprovision

--- a/versioned_docs/version-2.3/k3d/faq.mdx
+++ b/versioned_docs/version-2.3/k3d/faq.mdx
@@ -1,7 +1,7 @@
 ---
 title: FAQ
 description: frequently asked quesitons about the kubefirst platform
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import FAQ from "../common/faq.mdx";

--- a/versioned_docs/version-2.3/k3d/gitops-catalog.mdx
+++ b/versioned_docs/version-2.3/k3d/gitops-catalog.mdx
@@ -5,7 +5,7 @@ sidebar_label: GitOps Catalog
 description: using the kubefirst gitops catalog
 keywords:
   - aws
-image: 'https://docs.kubefirst.io/img/logo.svg'
+image: 'https://kubefirst.konstruct.io/docs/img/logo.svg'
 ---
 
 import GitOpsCatalog from '../common/gitops-catalog.mdx';

--- a/versioned_docs/version-2.3/k3d/overview.mdx
+++ b/versioned_docs/version-2.3/k3d/overview.mdx
@@ -3,7 +3,7 @@ hide_title: true
 sidebar_label: Overview
 sidebar_position: 1
 description: an overview of the kubefirst platform
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import Tabs from "@theme/Tabs";

--- a/versioned_docs/version-2.3/k3d/quick-start/install.mdx
+++ b/versioned_docs/version-2.3/k3d/quick-start/install.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: Install
 sidebar_position: 2
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import Tabs from "@theme/Tabs";

--- a/versioned_docs/version-2.3/k3d/quick-start/repositories.mdx
+++ b/versioned_docs/version-2.3/k3d/quick-start/repositories.mdx
@@ -2,7 +2,7 @@
 title: Repositories
 sidebar_position: 3
 description: the git repositories created by the kubefirst platform
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import REPOSITORES from "../../common/repositories.mdx";

--- a/versioned_docs/version-2.3/vultr/credits.mdx
+++ b/versioned_docs/version-2.3/vultr/credits.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: Credits
 description: credit to all the awesome open source projects
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import CommonCredits from "../common/credits.mdx";

--- a/versioned_docs/version-2.3/vultr/deprovision.mdx
+++ b/versioned_docs/version-2.3/vultr/deprovision.mdx
@@ -5,7 +5,7 @@ sidebar_label: Deprovision
 description: how to deprovision your kubefirst platform
 keywords:
   - aws
-image: 'https://docs.kubefirst.io/img/logo.svg'
+image: 'https://kubefirst.konstruct.io/docs/img/logo.svg'
 ---
 
 import Deprovision from '../common/deprovision.mdx';

--- a/versioned_docs/version-2.3/vultr/faq.mdx
+++ b/versioned_docs/version-2.3/vultr/faq.mdx
@@ -1,7 +1,7 @@
 ---
 title: FAQ
 description: frequently asked quesitons about the kubefirst platform
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import FAQ from "../common/faq.mdx";

--- a/versioned_docs/version-2.3/vultr/gitops-catalog.mdx
+++ b/versioned_docs/version-2.3/vultr/gitops-catalog.mdx
@@ -5,7 +5,7 @@ sidebar_label: GitOps Catalog
 description: using the kubefirst gitops catalog
 keywords:
   - aws
-image: 'https://docs.kubefirst.io/img/logo.svg'
+image: 'https://kubefirst.konstruct.io/docs/img/logo.svg'
 ---
 
 import GitOpsCatalog from '../common/gitops-catalog.mdx';

--- a/versioned_docs/version-2.3/vultr/overview.mdx
+++ b/versioned_docs/version-2.3/vultr/overview.mdx
@@ -3,7 +3,7 @@ hide_title: true
 sidebar_label: Overview
 sidebar_position: 1
 description: an overview of kubefirst on a Vultr kubernetes cluster
-image: 'https://docs.kubefirst.io/img/logo.svg'
+image: 'https://kubefirst.konstruct.io/docs/img/logo.svg'
 ---
 
 import Tabs from '@theme/Tabs';

--- a/versioned_docs/version-2.3/vultr/quick-start/cluster-management.mdx
+++ b/versioned_docs/version-2.3/vultr/quick-start/cluster-management.mdx
@@ -2,7 +2,7 @@
 title: Cluster Management
 sidebar_position: 3
 description: cluster creation and lifecycle management powered by gitops
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 :::note

--- a/versioned_docs/version-2.3/vultr/quick-start/install/cli.mdx
+++ b/versioned_docs/version-2.3/vultr/quick-start/install/cli.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: CLI Installer
 sidebar_position: 3
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import Tabs from "@theme/Tabs";

--- a/versioned_docs/version-2.3/vultr/quick-start/install/ui.mdx
+++ b/versioned_docs/version-2.3/vultr/quick-start/install/ui.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: Console UI
 sidebar_position: 1
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 import UI from "../../../common/ui.mdx";
 

--- a/versioned_docs/version-2.3/vultr/quick-start/repositories.mdx
+++ b/versioned_docs/version-2.3/vultr/quick-start/repositories.mdx
@@ -2,7 +2,7 @@
 title: Repositories
 sidebar_position: 3
 description: the git repositories created by the kubefirst platform
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import REPOSITORES from "../../common/repositories.mdx";

--- a/versioned_docs/version-2.4/akamai/credits.mdx
+++ b/versioned_docs/version-2.4/akamai/credits.mdx
@@ -1,7 +1,7 @@
 ---
 title: Credits
 description: credit to all the awesome open source projects
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import CommonCredits from "../common/credits.mdx";

--- a/versioned_docs/version-2.4/akamai/deprovision.mdx
+++ b/versioned_docs/version-2.4/akamai/deprovision.mdx
@@ -5,7 +5,7 @@ sidebar_label: Deprovision
 description: how to deprovision your kubefirst platform
 keywords:
   - aws
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import Deprovision from '../common/deprovision.mdx';

--- a/versioned_docs/version-2.4/akamai/faq.mdx
+++ b/versioned_docs/version-2.4/akamai/faq.mdx
@@ -1,7 +1,7 @@
 ---
 title: FAQ
 description: frequently asked quesitons about the kubefirst platform
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import FAQ from "../common/faq.mdx";

--- a/versioned_docs/version-2.4/akamai/gitops-catalog.mdx
+++ b/versioned_docs/version-2.4/akamai/gitops-catalog.mdx
@@ -5,7 +5,7 @@ sidebar_label: GitOps Catalog
 description: using the kubefirst gitops catalog
 keywords:
   - aws
-image: 'https://docs.kubefirst.io/img/logo.svg'
+image: 'https://kubefirst.konstruct.io/docs/img/logo.svg'
 ---
 
 import GitOpsCatalog from '../common/gitops-catalog.mdx';

--- a/versioned_docs/version-2.4/akamai/overview.mdx
+++ b/versioned_docs/version-2.4/akamai/overview.mdx
@@ -2,7 +2,7 @@
 sidebar_label: Overview
 sidebar_position: 1
 description: an overview of kubefirst on a Akamai kubernetes cluster
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import Tabs from "@theme/Tabs";

--- a/versioned_docs/version-2.4/akamai/quick-start/cluster-management.mdx
+++ b/versioned_docs/version-2.4/akamai/quick-start/cluster-management.mdx
@@ -2,7 +2,7 @@
 title: Cluster Management
 sidebar_position: 3
 description: cluster creation and lifecycle management powered by gitops
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import CLUSTERS from "../../common/clusters.mdx";

--- a/versioned_docs/version-2.4/akamai/quick-start/install/cli.mdx
+++ b/versioned_docs/version-2.4/akamai/quick-start/install/cli.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: CLI Installer
 sidebar_position: 3
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import Tabs from "@theme/Tabs";

--- a/versioned_docs/version-2.4/akamai/quick-start/install/ui.mdx
+++ b/versioned_docs/version-2.4/akamai/quick-start/install/ui.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: UI Installer
 sidebar_position: 2
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 import UI from "../../../common/ui.mdx";
 

--- a/versioned_docs/version-2.4/akamai/quick-start/repositories.mdx
+++ b/versioned_docs/version-2.4/akamai/quick-start/repositories.mdx
@@ -2,7 +2,7 @@
 title: Repositories
 sidebar_position: 3
 description: the git repositories created by the kubefirst platform
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import REPOSITORES from "../../common/repositories.mdx";

--- a/versioned_docs/version-2.4/aws/credits.mdx
+++ b/versioned_docs/version-2.4/aws/credits.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: Credits
 description: how to destroy your kubefirst platform
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import Credits from "../common/credits.mdx";

--- a/versioned_docs/version-2.4/aws/deprovision.mdx
+++ b/versioned_docs/version-2.4/aws/deprovision.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: Deprovision
 description: how to destroy your kubefirst platform
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import Deprovision from '../common/deprovision.mdx';

--- a/versioned_docs/version-2.4/aws/faq.mdx
+++ b/versioned_docs/version-2.4/aws/faq.mdx
@@ -1,7 +1,7 @@
 ---
 title: FAQ
 description: frequently asked quesitons about the platform
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import FAQ from "../common/faq.mdx";

--- a/versioned_docs/version-2.4/aws/gitops-catalog.mdx
+++ b/versioned_docs/version-2.4/aws/gitops-catalog.mdx
@@ -5,7 +5,7 @@ sidebar_label: GitOps Catalog
 description: using the kubefirst gitops catalog
 keywords:
   - aws
-image: 'https://docs.kubefirst.io/img/logo.svg'
+image: 'https://kubefirst.konstruct.io/docs/img/logo.svg'
 ---
 
 import GitOpsCatalog from '../common/gitops-catalog.mdx';

--- a/versioned_docs/version-2.4/aws/overview.mdx
+++ b/versioned_docs/version-2.4/aws/overview.mdx
@@ -3,7 +3,7 @@ hide_title: true
 sidebar_label: Overview
 sidebar_position: 1
 description: an overview of the kubefirst platform
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import Tabs from "@theme/Tabs";

--- a/versioned_docs/version-2.4/aws/quick-start/cluster-management.mdx
+++ b/versioned_docs/version-2.4/aws/quick-start/cluster-management.mdx
@@ -2,7 +2,7 @@
 title: Cluster Management
 sidebar_position: 3
 description: cluster creation and lifecycle management powered by gitops
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 :::note

--- a/versioned_docs/version-2.4/aws/quick-start/iac-and-app-delivery.mdx
+++ b/versioned_docs/version-2.4/aws/quick-start/iac-and-app-delivery.mdx
@@ -3,7 +3,7 @@ hide_title: true
 sidebar_label: IAC and App Delivery
 sidebar_position: 3
 description: an overview of the kubefirst platform on aws elastic kubernetes service (EKS)
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 ## Step 1: Console UI

--- a/versioned_docs/version-2.4/aws/quick-start/install/cli.mdx
+++ b/versioned_docs/version-2.4/aws/quick-start/install/cli.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: CLI Installer
 sidebar_position: 3
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import Tabs from "@theme/Tabs";

--- a/versioned_docs/version-2.4/aws/quick-start/install/ui.mdx
+++ b/versioned_docs/version-2.4/aws/quick-start/install/ui.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: Console UI
 sidebar_position: 1
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 import UI from "../../../common/ui.mdx";
 

--- a/versioned_docs/version-2.4/aws/quick-start/repositories.mdx
+++ b/versioned_docs/version-2.4/aws/quick-start/repositories.mdx
@@ -2,7 +2,7 @@
 title: Repositories
 sidebar_position: 3
 description: the git repositories created by the kubefirst platform
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import REPOSITORES from "../../common/repositories.mdx";

--- a/versioned_docs/version-2.4/civo/credits.mdx
+++ b/versioned_docs/version-2.4/civo/credits.mdx
@@ -1,7 +1,7 @@
 ---
 title: Credits
 description: credit to all the awesome open source projects
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import CommonCredits from "../common/credits.mdx";

--- a/versioned_docs/version-2.4/civo/deprovision.mdx
+++ b/versioned_docs/version-2.4/civo/deprovision.mdx
@@ -5,7 +5,7 @@ sidebar_label: Deprovision
 description: how to deprovision your kubefirst platform
 keywords:
   - aws
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import Deprovision from '../common/deprovision.mdx';

--- a/versioned_docs/version-2.4/civo/faq.mdx
+++ b/versioned_docs/version-2.4/civo/faq.mdx
@@ -1,7 +1,7 @@
 ---
 title: FAQ
 description: frequently asked quesitons about the kubefirst platform
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import FAQ from "../common/faq.mdx";

--- a/versioned_docs/version-2.4/civo/gitops-catalog.mdx
+++ b/versioned_docs/version-2.4/civo/gitops-catalog.mdx
@@ -5,7 +5,7 @@ sidebar_label: GitOps Catalog
 description: using the kubefirst gitops catalog
 keywords:
   - aws
-image: 'https://docs.kubefirst.io/img/kubefirst.svg'
+image: 'https://kubefirst.konstruct.io/docs/img/kubefirst.svg'
 ---
 
 import GitOpsCatalog from '../common/gitops-catalog.mdx';

--- a/versioned_docs/version-2.4/civo/overview.mdx
+++ b/versioned_docs/version-2.4/civo/overview.mdx
@@ -2,7 +2,7 @@
 sidebar_label: Overview
 sidebar_position: 1
 description: an overview of kubefirst on a civo kubernetes cluster
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import Tabs from "@theme/Tabs";

--- a/versioned_docs/version-2.4/civo/quick-start/cluster-management.mdx
+++ b/versioned_docs/version-2.4/civo/quick-start/cluster-management.mdx
@@ -2,7 +2,7 @@
 title: Cluster Management
 sidebar_position: 3
 description: cluster creation and lifecycle management powered by gitops
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import CLUSTERS from "../../common/clusters.mdx";

--- a/versioned_docs/version-2.4/civo/quick-start/install/cli.mdx
+++ b/versioned_docs/version-2.4/civo/quick-start/install/cli.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: CLI Installer
 sidebar_position: 3
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import Tabs from "@theme/Tabs";

--- a/versioned_docs/version-2.4/civo/quick-start/install/marketplace.mdx
+++ b/versioned_docs/version-2.4/civo/quick-start/install/marketplace.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: Civo Marketplace
 sidebar_position: 1
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 # Install kubefirst using the Civo Marketplace

--- a/versioned_docs/version-2.4/civo/quick-start/install/ui.mdx
+++ b/versioned_docs/version-2.4/civo/quick-start/install/ui.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: UI Installer
 sidebar_position: 2
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 import UI from "../../../common/ui.mdx";
 

--- a/versioned_docs/version-2.4/civo/quick-start/repositories.mdx
+++ b/versioned_docs/version-2.4/civo/quick-start/repositories.mdx
@@ -2,7 +2,7 @@
 title: Repositories
 sidebar_position: 3
 description: the git repositories created by the kubefirst platform
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import REPOSITORES from "../../common/repositories.mdx";

--- a/versioned_docs/version-2.4/common/deprovision.mdx
+++ b/versioned_docs/version-2.4/common/deprovision.mdx
@@ -27,7 +27,7 @@ If you are coming from a cloud marketplace, and didn't use the kubefirst CLI, yo
 brew install konstructio/taps/kubefirst
 ```
 
-More information in the [installation steps from our documentation](https://docs.kubefirst.io/next/aws/quick-start/install/cli#local-prerequisites).
+More information in the [installation steps from our documentation](https://kubefirst.konstruct.io/docs/next/aws/quick-start/install/cli#local-prerequisites).
 
 ### Kubernetes CLI
 

--- a/versioned_docs/version-2.4/common/repositories.mdx
+++ b/versioned_docs/version-2.4/common/repositories.mdx
@@ -2,7 +2,7 @@
 title: Repositories
 sidebar_position: 2
 description: the git repositories created by the kubefirst platform
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import Tabs from "@theme/Tabs";

--- a/versioned_docs/version-2.4/do/credits.mdx
+++ b/versioned_docs/version-2.4/do/credits.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: Credits
 description: credit to all the awesome open source projects
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import CommonCredits from "../common/credits.mdx";

--- a/versioned_docs/version-2.4/do/deprovision.mdx
+++ b/versioned_docs/version-2.4/do/deprovision.mdx
@@ -5,7 +5,7 @@ sidebar_label: Deprovision
 description: how to deprovision your kubefirst platform
 keywords:
   - aws
-image: 'https://docs.kubefirst.io/img/logo.svg'
+image: 'https://kubefirst.konstruct.io/docs/img/logo.svg'
 ---
 
 import Deprovision from '../common/deprovision.mdx';

--- a/versioned_docs/version-2.4/do/faq.mdx
+++ b/versioned_docs/version-2.4/do/faq.mdx
@@ -1,7 +1,7 @@
 ---
 title: FAQ
 description: frequently asked quesitons about the kubefirst platform
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import FAQ from "../common/faq.mdx";

--- a/versioned_docs/version-2.4/do/gitops-catalog.mdx
+++ b/versioned_docs/version-2.4/do/gitops-catalog.mdx
@@ -5,7 +5,7 @@ sidebar_label: GitOps Catalog
 description: using the kubefirst gitops catalog
 keywords:
   - aws
-image: 'https://docs.kubefirst.io/img/logo.svg'
+image: 'https://kubefirst.konstruct.io/docs/img/logo.svg'
 ---
 
 import GitOpsCatalog from '../common/gitops-catalog.mdx';

--- a/versioned_docs/version-2.4/do/overview.mdx
+++ b/versioned_docs/version-2.4/do/overview.mdx
@@ -3,7 +3,7 @@ hide_title: true
 sidebar_label: Overview
 sidebar_position: 1
 description: an overview of kubefirst on a DigitalOcean kubernetes cluster
-image: 'https://docs.kubefirst.io/img/kubefirst.svg'
+image: 'https://kubefirst.konstruct.io/docs/img/kubefirst.svg'
 ---
 
 import Tabs from '@theme/Tabs';

--- a/versioned_docs/version-2.4/do/quick-start/cluster-management.mdx
+++ b/versioned_docs/version-2.4/do/quick-start/cluster-management.mdx
@@ -2,7 +2,7 @@
 title: Cluster Management
 sidebar_position: 3
 description: cluster creation and lifecycle management powered by gitops
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 :::note

--- a/versioned_docs/version-2.4/do/quick-start/install/cli.mdx
+++ b/versioned_docs/version-2.4/do/quick-start/install/cli.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: CLI Installer
 sidebar_position: 3
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import Tabs from "@theme/Tabs";

--- a/versioned_docs/version-2.4/do/quick-start/install/marketplace.mdx
+++ b/versioned_docs/version-2.4/do/quick-start/install/marketplace.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: DigitalOcean Marketplace
 sidebar_position: 1
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 # Install kubefirst using the DigitalOcean Marketplace

--- a/versioned_docs/version-2.4/do/quick-start/install/ui.mdx
+++ b/versioned_docs/version-2.4/do/quick-start/install/ui.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: Console UI
 sidebar_position: 1
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import UI from "../../../common/ui.mdx";

--- a/versioned_docs/version-2.4/do/quick-start/repositories.mdx
+++ b/versioned_docs/version-2.4/do/quick-start/repositories.mdx
@@ -2,7 +2,7 @@
 title: Repositories
 sidebar_position: 3
 description: the git repositories created by the kubefirst platform
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import REPOSITORES from "../../common/repositories.mdx";

--- a/versioned_docs/version-2.4/gcp/credits.mdx
+++ b/versioned_docs/version-2.4/gcp/credits.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: Credits
 description: credit to all the awesome open source projects
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import CommonCredits from "../common/credits.mdx";

--- a/versioned_docs/version-2.4/gcp/deprovision.mdx
+++ b/versioned_docs/version-2.4/gcp/deprovision.mdx
@@ -5,7 +5,7 @@ sidebar_label: Deprovision
 description: how to deprovision your kubefirst platform
 keywords:
   - aws
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import Deprovision from '../common/deprovision.mdx';

--- a/versioned_docs/version-2.4/gcp/faq.mdx
+++ b/versioned_docs/version-2.4/gcp/faq.mdx
@@ -1,7 +1,7 @@
 ---
 title: FAQ
 description: frequently asked quesitons about the kubefirst platform
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import FAQ from "../common/faq.mdx";

--- a/versioned_docs/version-2.4/gcp/gitops-catalog.mdx
+++ b/versioned_docs/version-2.4/gcp/gitops-catalog.mdx
@@ -5,7 +5,7 @@ sidebar_label: GitOps Catalog
 description: using the kubefirst gitops catalog
 keywords:
   - aws
-image: 'https://docs.kubefirst.io/img/logo.svg'
+image: 'https://kubefirst.konstruct.io/docs/img/logo.svg'
 ---
 
 import GitOpsCatalog from '../common/gitops-catalog.mdx';

--- a/versioned_docs/version-2.4/gcp/overview.mdx
+++ b/versioned_docs/version-2.4/gcp/overview.mdx
@@ -3,7 +3,7 @@ hide_title: true
 sidebar_label: Overview
 sidebar_position: 1
 description: an overview of kubefirst on a Google Cloud kubernetes cluster
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 
 ---
 import Tabs from "@theme/Tabs";

--- a/versioned_docs/version-2.4/gcp/quick-start/cluster-management.mdx
+++ b/versioned_docs/version-2.4/gcp/quick-start/cluster-management.mdx
@@ -2,7 +2,7 @@
 title: Cluster Management
 sidebar_position: 3
 description: cluster creation and lifecycle management powered by gitops
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 :::note

--- a/versioned_docs/version-2.4/gcp/quick-start/install/cli.mdx
+++ b/versioned_docs/version-2.4/gcp/quick-start/install/cli.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: CLI Installer
 sidebar_position: 3
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import Tabs from "@theme/Tabs";

--- a/versioned_docs/version-2.4/gcp/quick-start/install/ui.mdx
+++ b/versioned_docs/version-2.4/gcp/quick-start/install/ui.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: Console UI
 sidebar_position: 1
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 import UI from "../../../common/ui.mdx";
 

--- a/versioned_docs/version-2.4/gcp/quick-start/repositories.mdx
+++ b/versioned_docs/version-2.4/gcp/quick-start/repositories.mdx
@@ -2,7 +2,7 @@
 title: Repositories
 sidebar_position: 3
 description: the git repositories created by the kubefirst platform
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import REPOSITORES from "../../common/repositories.mdx";

--- a/versioned_docs/version-2.4/k3d/credits.mdx
+++ b/versioned_docs/version-2.4/k3d/credits.mdx
@@ -3,7 +3,7 @@ hide_title: true
 sidebar_label: Credits
 sidebar_position: 4
 description: Credits for the awesome open source we use
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import Credits from "../common/credits.mdx";

--- a/versioned_docs/version-2.4/k3d/deprovision.mdx
+++ b/versioned_docs/version-2.4/k3d/deprovision.mdx
@@ -3,7 +3,7 @@ hide_title: true
 sidebar_label: Deprovision
 sidebar_position: 2
 description: how to deprovision your kubefirst platform
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 # Deprovision

--- a/versioned_docs/version-2.4/k3d/faq.mdx
+++ b/versioned_docs/version-2.4/k3d/faq.mdx
@@ -1,7 +1,7 @@
 ---
 title: FAQ
 description: frequently asked quesitons about the kubefirst platform
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import FAQ from "../common/faq.mdx";

--- a/versioned_docs/version-2.4/k3d/gitops-catalog.mdx
+++ b/versioned_docs/version-2.4/k3d/gitops-catalog.mdx
@@ -5,7 +5,7 @@ sidebar_label: GitOps Catalog
 description: using the kubefirst gitops catalog
 keywords:
   - aws
-image: 'https://docs.kubefirst.io/img/logo.svg'
+image: 'https://kubefirst.konstruct.io/docs/img/logo.svg'
 ---
 
 import GitOpsCatalog from '../common/gitops-catalog.mdx';

--- a/versioned_docs/version-2.4/k3d/overview.mdx
+++ b/versioned_docs/version-2.4/k3d/overview.mdx
@@ -3,7 +3,7 @@ hide_title: true
 sidebar_label: Overview
 sidebar_position: 1
 description: an overview of the kubefirst platform
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import Tabs from "@theme/Tabs";

--- a/versioned_docs/version-2.4/k3d/quick-start/install.mdx
+++ b/versioned_docs/version-2.4/k3d/quick-start/install.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: Install
 sidebar_position: 2
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import Tabs from "@theme/Tabs";

--- a/versioned_docs/version-2.4/k3d/quick-start/repositories.mdx
+++ b/versioned_docs/version-2.4/k3d/quick-start/repositories.mdx
@@ -2,7 +2,7 @@
 title: Repositories
 sidebar_position: 3
 description: the git repositories created by the kubefirst platform
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import REPOSITORES from "../../common/repositories.mdx";

--- a/versioned_docs/version-2.4/k3s/credits.mdx
+++ b/versioned_docs/version-2.4/k3s/credits.mdx
@@ -1,7 +1,7 @@
 ---
 title: Credits
 description: credit to all the awesome open source projects
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import CommonCredits from "../common/credits.mdx";

--- a/versioned_docs/version-2.4/k3s/deprovision.mdx
+++ b/versioned_docs/version-2.4/k3s/deprovision.mdx
@@ -5,7 +5,7 @@ sidebar_label: Deprovision
 description: how to deprovision your kubefirst platform
 keywords:
   - aws
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import Deprovision from '../common/deprovision.mdx';

--- a/versioned_docs/version-2.4/k3s/faq.mdx
+++ b/versioned_docs/version-2.4/k3s/faq.mdx
@@ -1,7 +1,7 @@
 ---
 title: FAQ
 description: frequently asked quesitons about the kubefirst platform
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import FAQ from "../common/faq.mdx";

--- a/versioned_docs/version-2.4/k3s/gitops-catalog.mdx
+++ b/versioned_docs/version-2.4/k3s/gitops-catalog.mdx
@@ -5,7 +5,7 @@ sidebar_label: GitOps Catalog
 description: using the kubefirst gitops catalog
 keywords:
   - aws
-image: 'https://docs.kubefirst.io/img/logo.svg'
+image: 'https://kubefirst.konstruct.io/docs/img/logo.svg'
 ---
 
 import GitOpsCatalog from '../common/gitops-catalog.mdx';

--- a/versioned_docs/version-2.4/k3s/overview.mdx
+++ b/versioned_docs/version-2.4/k3s/overview.mdx
@@ -2,7 +2,7 @@
 sidebar_label: Overview
 sidebar_position: 1
 description: an overview of kubefirst on a K3s kubernetes cluster
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import Tabs from "@theme/Tabs";

--- a/versioned_docs/version-2.4/k3s/quick-start/cluster-management.mdx
+++ b/versioned_docs/version-2.4/k3s/quick-start/cluster-management.mdx
@@ -2,7 +2,7 @@
 title: Cluster Management
 sidebar_position: 3
 description: cluster creation and lifecycle management powered by gitops
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import CLUSTERS from "../../common/clusters.mdx";

--- a/versioned_docs/version-2.4/k3s/quick-start/install/cli.mdx
+++ b/versioned_docs/version-2.4/k3s/quick-start/install/cli.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: CLI Installer
 sidebar_position: 3
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import Tabs from "@theme/Tabs";

--- a/versioned_docs/version-2.4/k3s/quick-start/install/ui.mdx
+++ b/versioned_docs/version-2.4/k3s/quick-start/install/ui.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: UI Installer
 sidebar_position: 2
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 <!-- markdownlint-disable MD049 -->

--- a/versioned_docs/version-2.4/k3s/quick-start/repositories.mdx
+++ b/versioned_docs/version-2.4/k3s/quick-start/repositories.mdx
@@ -2,7 +2,7 @@
 title: Repositories
 sidebar_position: 3
 description: the git repositories created by the kubefirst platform
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import REPOSITORES from "../../common/repositories.mdx";

--- a/versioned_docs/version-2.4/vultr/credits.mdx
+++ b/versioned_docs/version-2.4/vultr/credits.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: Credits
 description: credit to all the awesome open source projects
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import CommonCredits from "../common/credits.mdx";

--- a/versioned_docs/version-2.4/vultr/deprovision.mdx
+++ b/versioned_docs/version-2.4/vultr/deprovision.mdx
@@ -5,7 +5,7 @@ sidebar_label: Deprovision
 description: how to deprovision your kubefirst platform
 keywords:
   - aws
-image: 'https://docs.kubefirst.io/img/logo.svg'
+image: 'https://kubefirst.konstruct.io/docs/img/logo.svg'
 ---
 
 import Deprovision from '../common/deprovision.mdx';

--- a/versioned_docs/version-2.4/vultr/faq.mdx
+++ b/versioned_docs/version-2.4/vultr/faq.mdx
@@ -1,7 +1,7 @@
 ---
 title: FAQ
 description: frequently asked quesitons about the kubefirst platform
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import FAQ from "../common/faq.mdx";

--- a/versioned_docs/version-2.4/vultr/gitops-catalog.mdx
+++ b/versioned_docs/version-2.4/vultr/gitops-catalog.mdx
@@ -5,7 +5,7 @@ sidebar_label: GitOps Catalog
 description: using the kubefirst gitops catalog
 keywords:
   - aws
-image: 'https://docs.kubefirst.io/img/logo.svg'
+image: 'https://kubefirst.konstruct.io/docs/img/logo.svg'
 ---
 
 import GitOpsCatalog from '../common/gitops-catalog.mdx';

--- a/versioned_docs/version-2.4/vultr/overview.mdx
+++ b/versioned_docs/version-2.4/vultr/overview.mdx
@@ -3,7 +3,7 @@ hide_title: true
 sidebar_label: Overview
 sidebar_position: 1
 description: an overview of kubefirst on a Vultr kubernetes cluster
-image: 'https://docs.kubefirst.io/img/kubefirst.svg'
+image: 'https://kubefirst.konstruct.io/docs/img/kubefirst.svg'
 ---
 
 import Tabs from '@theme/Tabs';

--- a/versioned_docs/version-2.4/vultr/quick-start/cluster-management.mdx
+++ b/versioned_docs/version-2.4/vultr/quick-start/cluster-management.mdx
@@ -2,7 +2,7 @@
 title: Cluster Management
 sidebar_position: 3
 description: cluster creation and lifecycle management powered by gitops
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 :::note

--- a/versioned_docs/version-2.4/vultr/quick-start/install/cli.mdx
+++ b/versioned_docs/version-2.4/vultr/quick-start/install/cli.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: CLI Installer
 sidebar_position: 3
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import Tabs from "@theme/Tabs";

--- a/versioned_docs/version-2.4/vultr/quick-start/install/ui.mdx
+++ b/versioned_docs/version-2.4/vultr/quick-start/install/ui.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: Console UI
 sidebar_position: 1
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 import UI from "../../../common/ui.mdx";
 

--- a/versioned_docs/version-2.4/vultr/quick-start/repositories.mdx
+++ b/versioned_docs/version-2.4/vultr/quick-start/repositories.mdx
@@ -2,7 +2,7 @@
 title: Repositories
 sidebar_position: 3
 description: the git repositories created by the kubefirst platform
-image: "https://docs.kubefirst.io/img/logo.svg"
+image: "https://kubefirst.konstruct.io/docs/img/logo.svg"
 ---
 
 import REPOSITORES from "../../common/repositories.mdx";

--- a/versioned_docs/version-2.5/akamai/credits.mdx
+++ b/versioned_docs/version-2.5/akamai/credits.mdx
@@ -1,7 +1,7 @@
 ---
 title: Credits
 description: credit to all the awesome open source projects
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import CommonCredits from "../common/credits.mdx";

--- a/versioned_docs/version-2.5/akamai/deprovision.mdx
+++ b/versioned_docs/version-2.5/akamai/deprovision.mdx
@@ -5,7 +5,7 @@ sidebar_label: Deprovision
 description: how to deprovision your kubefirst platform
 keywords:
   - aws
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import Deprovision from '../common/deprovision.mdx';

--- a/versioned_docs/version-2.5/akamai/faq.mdx
+++ b/versioned_docs/version-2.5/akamai/faq.mdx
@@ -1,7 +1,7 @@
 ---
 title: FAQ
 description: frequently asked quesitons about the kubefirst platform
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import FAQ from "../common/faq.mdx";

--- a/versioned_docs/version-2.5/akamai/gitops-catalog.mdx
+++ b/versioned_docs/version-2.5/akamai/gitops-catalog.mdx
@@ -5,7 +5,7 @@ sidebar_label: GitOps Catalog
 description: using the kubefirst gitops catalog
 keywords:
   - aws
-image: 'https://docs.kubefirst.io/img/kubefirst.svg'
+image: 'https://kubefirst.konstruct.io/docs/img/kubefirst.svg'
 ---
 
 import GitOpsCatalog from '../common/gitops-catalog.mdx';

--- a/versioned_docs/version-2.5/akamai/overview.mdx
+++ b/versioned_docs/version-2.5/akamai/overview.mdx
@@ -2,7 +2,7 @@
 sidebar_label: Overview
 sidebar_position: 1
 description: an overview of kubefirst on a Akamai kubernetes cluster
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import Tabs from "@theme/Tabs";

--- a/versioned_docs/version-2.5/akamai/quick-start/cluster-management.mdx
+++ b/versioned_docs/version-2.5/akamai/quick-start/cluster-management.mdx
@@ -2,7 +2,7 @@
 title: Cluster Management
 sidebar_position: 3
 description: cluster creation and lifecycle management powered by gitops
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import CLUSTERS from "../../common/clusters.mdx";

--- a/versioned_docs/version-2.5/akamai/quick-start/install/cli.mdx
+++ b/versioned_docs/version-2.5/akamai/quick-start/install/cli.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: CLI Installer
 sidebar_position: 3
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import Tabs from "@theme/Tabs";

--- a/versioned_docs/version-2.5/akamai/quick-start/install/ui.mdx
+++ b/versioned_docs/version-2.5/akamai/quick-start/install/ui.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: UI Installer
 sidebar_position: 2
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 import UI from "../../../common/ui.mdx";
 

--- a/versioned_docs/version-2.5/akamai/quick-start/repositories.mdx
+++ b/versioned_docs/version-2.5/akamai/quick-start/repositories.mdx
@@ -2,7 +2,7 @@
 title: Repositories
 sidebar_position: 3
 description: the git repositories created by the kubefirst platform
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import REPOSITORES from "../../common/repositories.mdx";

--- a/versioned_docs/version-2.5/aws/credits.mdx
+++ b/versioned_docs/version-2.5/aws/credits.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: Credits
 description: how to destroy your kubefirst platform
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import Credits from "../common/credits.mdx";

--- a/versioned_docs/version-2.5/aws/deprovision.mdx
+++ b/versioned_docs/version-2.5/aws/deprovision.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: Deprovision
 description: how to destroy your kubefirst platform
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import Deprovision from '../common/deprovision.mdx';

--- a/versioned_docs/version-2.5/aws/faq.mdx
+++ b/versioned_docs/version-2.5/aws/faq.mdx
@@ -1,7 +1,7 @@
 ---
 title: FAQ
 description: frequently asked quesitons about the platform
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import FAQ from "../common/faq.mdx";

--- a/versioned_docs/version-2.5/aws/gitops-catalog.mdx
+++ b/versioned_docs/version-2.5/aws/gitops-catalog.mdx
@@ -5,7 +5,7 @@ sidebar_label: GitOps Catalog
 description: using the kubefirst gitops catalog
 keywords:
   - aws
-image: 'https://docs.kubefirst.io/img/kubefirst.svg'
+image: 'https://kubefirst.konstruct.io/docs/img/kubefirst.svg'
 ---
 
 import GitOpsCatalog from '../common/gitops-catalog.mdx';

--- a/versioned_docs/version-2.5/aws/overview.mdx
+++ b/versioned_docs/version-2.5/aws/overview.mdx
@@ -3,7 +3,7 @@ hide_title: true
 sidebar_label: Overview
 sidebar_position: 1
 description: an overview of the kubefirst platform
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import Tabs from "@theme/Tabs";

--- a/versioned_docs/version-2.5/aws/quick-start/cluster-management.mdx
+++ b/versioned_docs/version-2.5/aws/quick-start/cluster-management.mdx
@@ -2,7 +2,7 @@
 title: Cluster Management
 sidebar_position: 3
 description: cluster creation and lifecycle management powered by gitops
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 :::note

--- a/versioned_docs/version-2.5/aws/quick-start/iac-and-app-delivery.mdx
+++ b/versioned_docs/version-2.5/aws/quick-start/iac-and-app-delivery.mdx
@@ -3,7 +3,7 @@ hide_title: true
 sidebar_label: IAC and App Delivery
 sidebar_position: 3
 description: an overview of the kubefirst platform on aws elastic kubernetes service (EKS)
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 ## Step 1: Console UI

--- a/versioned_docs/version-2.5/aws/quick-start/install/cli.mdx
+++ b/versioned_docs/version-2.5/aws/quick-start/install/cli.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: CLI Installer
 sidebar_position: 3
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import Tabs from "@theme/Tabs";

--- a/versioned_docs/version-2.5/aws/quick-start/install/ui.mdx
+++ b/versioned_docs/version-2.5/aws/quick-start/install/ui.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: Console UI
 sidebar_position: 1
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 import UI from "../../../common/ui.mdx";
 

--- a/versioned_docs/version-2.5/aws/quick-start/repositories.mdx
+++ b/versioned_docs/version-2.5/aws/quick-start/repositories.mdx
@@ -2,7 +2,7 @@
 title: Repositories
 sidebar_position: 3
 description: the git repositories created by the kubefirst platform
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import REPOSITORES from "../../common/repositories.mdx";

--- a/versioned_docs/version-2.5/civo/credits.mdx
+++ b/versioned_docs/version-2.5/civo/credits.mdx
@@ -1,7 +1,7 @@
 ---
 title: Credits
 description: credit to all the awesome open source projects
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import CommonCredits from "../common/credits.mdx";

--- a/versioned_docs/version-2.5/civo/deprovision.mdx
+++ b/versioned_docs/version-2.5/civo/deprovision.mdx
@@ -5,7 +5,7 @@ sidebar_label: Deprovision
 description: how to deprovision your kubefirst platform
 keywords:
   - aws
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import Deprovision from '../common/deprovision.mdx';

--- a/versioned_docs/version-2.5/civo/faq.mdx
+++ b/versioned_docs/version-2.5/civo/faq.mdx
@@ -1,7 +1,7 @@
 ---
 title: FAQ
 description: frequently asked quesitons about the kubefirst platform
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import FAQ from "../common/faq.mdx";

--- a/versioned_docs/version-2.5/civo/gitops-catalog.mdx
+++ b/versioned_docs/version-2.5/civo/gitops-catalog.mdx
@@ -5,7 +5,7 @@ sidebar_label: GitOps Catalog
 description: using the kubefirst gitops catalog
 keywords:
   - aws
-image: 'https://docs.kubefirst.io/img/kubefirst.svg'
+image: 'https://kubefirst.konstruct.io/docs/img/kubefirst.svg'
 ---
 
 import GitOpsCatalog from '../common/gitops-catalog.mdx';

--- a/versioned_docs/version-2.5/civo/overview.mdx
+++ b/versioned_docs/version-2.5/civo/overview.mdx
@@ -2,7 +2,7 @@
 sidebar_label: Overview
 sidebar_position: 1
 description: an overview of kubefirst on a civo kubernetes cluster
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import Tabs from "@theme/Tabs";

--- a/versioned_docs/version-2.5/civo/quick-start/cluster-management.mdx
+++ b/versioned_docs/version-2.5/civo/quick-start/cluster-management.mdx
@@ -2,7 +2,7 @@
 title: Cluster Management
 sidebar_position: 3
 description: cluster creation and lifecycle management powered by gitops
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import CLUSTERS from "../../common/clusters.mdx";

--- a/versioned_docs/version-2.5/civo/quick-start/install/cli.mdx
+++ b/versioned_docs/version-2.5/civo/quick-start/install/cli.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: CLI Installer
 sidebar_position: 3
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import Tabs from "@theme/Tabs";

--- a/versioned_docs/version-2.5/civo/quick-start/install/marketplace.mdx
+++ b/versioned_docs/version-2.5/civo/quick-start/install/marketplace.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: Civo Marketplace
 sidebar_position: 1
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 # Install kubefirst using the Civo Marketplace

--- a/versioned_docs/version-2.5/civo/quick-start/install/ui.mdx
+++ b/versioned_docs/version-2.5/civo/quick-start/install/ui.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: UI Installer
 sidebar_position: 2
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 import UI from "../../../common/ui.mdx";
 

--- a/versioned_docs/version-2.5/civo/quick-start/repositories.mdx
+++ b/versioned_docs/version-2.5/civo/quick-start/repositories.mdx
@@ -2,7 +2,7 @@
 title: Repositories
 sidebar_position: 3
 description: the git repositories created by the kubefirst platform
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import REPOSITORES from "../../common/repositories.mdx";

--- a/versioned_docs/version-2.5/common/deprovision.mdx
+++ b/versioned_docs/version-2.5/common/deprovision.mdx
@@ -27,7 +27,7 @@ If you are coming from a cloud marketplace, and didn't use the kubefirst CLI, yo
 brew install konstructio/taps/kubefirst
 ```
 
-More information in the [installation steps from our documentation](https://docs.kubefirst.io/next/aws/quick-start/install/cli#local-prerequisites).
+More information in the [installation steps from our documentation](https://kubefirst.konstruct.io/docs/next/aws/quick-start/install/cli#local-prerequisites).
 
 ### Kubernetes CLI
 

--- a/versioned_docs/version-2.5/common/repositories.mdx
+++ b/versioned_docs/version-2.5/common/repositories.mdx
@@ -2,7 +2,7 @@
 title: Repositories
 sidebar_position: 2
 description: the git repositories created by the kubefirst platform
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import Tabs from "@theme/Tabs";

--- a/versioned_docs/version-2.5/do/credits.mdx
+++ b/versioned_docs/version-2.5/do/credits.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: Credits
 description: credit to all the awesome open source projects
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import CommonCredits from "../common/credits.mdx";

--- a/versioned_docs/version-2.5/do/deprovision.mdx
+++ b/versioned_docs/version-2.5/do/deprovision.mdx
@@ -5,7 +5,7 @@ sidebar_label: Deprovision
 description: how to deprovision your kubefirst platform
 keywords:
   - aws
-image: 'https://docs.kubefirst.io/img/kubefirst.svg'
+image: 'https://kubefirst.konstruct.io/docs/img/kubefirst.svg'
 ---
 
 import Deprovision from '../common/deprovision.mdx';

--- a/versioned_docs/version-2.5/do/faq.mdx
+++ b/versioned_docs/version-2.5/do/faq.mdx
@@ -1,7 +1,7 @@
 ---
 title: FAQ
 description: frequently asked quesitons about the kubefirst platform
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import FAQ from "../common/faq.mdx";

--- a/versioned_docs/version-2.5/do/gitops-catalog.mdx
+++ b/versioned_docs/version-2.5/do/gitops-catalog.mdx
@@ -5,7 +5,7 @@ sidebar_label: GitOps Catalog
 description: using the kubefirst gitops catalog
 keywords:
   - aws
-image: 'https://docs.kubefirst.io/img/kubefirst.svg'
+image: 'https://kubefirst.konstruct.io/docs/img/kubefirst.svg'
 ---
 
 import GitOpsCatalog from '../common/gitops-catalog.mdx';

--- a/versioned_docs/version-2.5/do/overview.mdx
+++ b/versioned_docs/version-2.5/do/overview.mdx
@@ -3,7 +3,7 @@ hide_title: true
 sidebar_label: Overview
 sidebar_position: 1
 description: an overview of kubefirst on a DigitalOcean kubernetes cluster
-image: 'https://docs.kubefirst.io/img/kubefirst.svg'
+image: 'https://kubefirst.konstruct.io/docs/img/kubefirst.svg'
 ---
 
 import Tabs from '@theme/Tabs';

--- a/versioned_docs/version-2.5/do/quick-start/cluster-management.mdx
+++ b/versioned_docs/version-2.5/do/quick-start/cluster-management.mdx
@@ -2,7 +2,7 @@
 title: Cluster Management
 sidebar_position: 3
 description: cluster creation and lifecycle management powered by gitops
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 :::note

--- a/versioned_docs/version-2.5/do/quick-start/install/cli.mdx
+++ b/versioned_docs/version-2.5/do/quick-start/install/cli.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: CLI Installer
 sidebar_position: 3
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import Tabs from "@theme/Tabs";

--- a/versioned_docs/version-2.5/do/quick-start/install/marketplace.mdx
+++ b/versioned_docs/version-2.5/do/quick-start/install/marketplace.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: DigitalOcean Marketplace
 sidebar_position: 1
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 # Install kubefirst using the DigitalOcean Marketplace

--- a/versioned_docs/version-2.5/do/quick-start/install/ui.mdx
+++ b/versioned_docs/version-2.5/do/quick-start/install/ui.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: Console UI
 sidebar_position: 1
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import UI from "../../../common/ui.mdx";

--- a/versioned_docs/version-2.5/do/quick-start/repositories.mdx
+++ b/versioned_docs/version-2.5/do/quick-start/repositories.mdx
@@ -2,7 +2,7 @@
 title: Repositories
 sidebar_position: 3
 description: the git repositories created by the kubefirst platform
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import REPOSITORES from "../../common/repositories.mdx";

--- a/versioned_docs/version-2.5/gcp/credits.mdx
+++ b/versioned_docs/version-2.5/gcp/credits.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: Credits
 description: credit to all the awesome open source projects
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import CommonCredits from "../common/credits.mdx";

--- a/versioned_docs/version-2.5/gcp/deprovision.mdx
+++ b/versioned_docs/version-2.5/gcp/deprovision.mdx
@@ -5,7 +5,7 @@ sidebar_label: Deprovision
 description: how to deprovision your kubefirst platform
 keywords:
   - aws
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import Deprovision from '../common/deprovision.mdx';

--- a/versioned_docs/version-2.5/gcp/faq.mdx
+++ b/versioned_docs/version-2.5/gcp/faq.mdx
@@ -1,7 +1,7 @@
 ---
 title: FAQ
 description: frequently asked quesitons about the kubefirst platform
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import FAQ from "../common/faq.mdx";

--- a/versioned_docs/version-2.5/gcp/gitops-catalog.mdx
+++ b/versioned_docs/version-2.5/gcp/gitops-catalog.mdx
@@ -5,7 +5,7 @@ sidebar_label: GitOps Catalog
 description: using the kubefirst gitops catalog
 keywords:
   - aws
-image: 'https://docs.kubefirst.io/img/kubefirst.svg'
+image: 'https://kubefirst.konstruct.io/docs/img/kubefirst.svg'
 ---
 
 import GitOpsCatalog from '../common/gitops-catalog.mdx';

--- a/versioned_docs/version-2.5/gcp/overview.mdx
+++ b/versioned_docs/version-2.5/gcp/overview.mdx
@@ -3,7 +3,7 @@ hide_title: true
 sidebar_label: Overview
 sidebar_position: 1
 description: an overview of kubefirst on a Google Cloud kubernetes cluster
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 
 ---
 import Tabs from "@theme/Tabs";

--- a/versioned_docs/version-2.5/gcp/quick-start/cluster-management.mdx
+++ b/versioned_docs/version-2.5/gcp/quick-start/cluster-management.mdx
@@ -2,7 +2,7 @@
 title: Cluster Management
 sidebar_position: 3
 description: cluster creation and lifecycle management powered by gitops
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 :::note

--- a/versioned_docs/version-2.5/gcp/quick-start/install/cli.mdx
+++ b/versioned_docs/version-2.5/gcp/quick-start/install/cli.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: CLI Installer
 sidebar_position: 3
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import Tabs from "@theme/Tabs";

--- a/versioned_docs/version-2.5/gcp/quick-start/install/ui.mdx
+++ b/versioned_docs/version-2.5/gcp/quick-start/install/ui.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: Console UI
 sidebar_position: 1
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 import UI from "../../../common/ui.mdx";
 

--- a/versioned_docs/version-2.5/gcp/quick-start/repositories.mdx
+++ b/versioned_docs/version-2.5/gcp/quick-start/repositories.mdx
@@ -2,7 +2,7 @@
 title: Repositories
 sidebar_position: 3
 description: the git repositories created by the kubefirst platform
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import REPOSITORES from "../../common/repositories.mdx";

--- a/versioned_docs/version-2.5/k3d/credits.mdx
+++ b/versioned_docs/version-2.5/k3d/credits.mdx
@@ -3,7 +3,7 @@ hide_title: true
 sidebar_label: Credits
 sidebar_position: 4
 description: Credits for the awesome open source we use
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import Credits from "../common/credits.mdx";

--- a/versioned_docs/version-2.5/k3d/deprovision.mdx
+++ b/versioned_docs/version-2.5/k3d/deprovision.mdx
@@ -3,7 +3,7 @@ hide_title: true
 sidebar_label: Deprovision
 sidebar_position: 2
 description: how to deprovision your kubefirst platform
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 # Deprovision

--- a/versioned_docs/version-2.5/k3d/faq.mdx
+++ b/versioned_docs/version-2.5/k3d/faq.mdx
@@ -1,7 +1,7 @@
 ---
 title: FAQ
 description: frequently asked quesitons about the kubefirst platform
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import FAQ from "../common/faq.mdx";

--- a/versioned_docs/version-2.5/k3d/gitops-catalog.mdx
+++ b/versioned_docs/version-2.5/k3d/gitops-catalog.mdx
@@ -5,7 +5,7 @@ sidebar_label: GitOps Catalog
 description: using the kubefirst gitops catalog
 keywords:
   - aws
-image: 'https://docs.kubefirst.io/img/kubefirst.svg'
+image: 'https://kubefirst.konstruct.io/docs/img/kubefirst.svg'
 ---
 
 import GitOpsCatalog from '../common/gitops-catalog.mdx';

--- a/versioned_docs/version-2.5/k3d/overview.mdx
+++ b/versioned_docs/version-2.5/k3d/overview.mdx
@@ -3,7 +3,7 @@ hide_title: true
 sidebar_label: Overview
 sidebar_position: 1
 description: an overview of the kubefirst platform
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import Tabs from "@theme/Tabs";

--- a/versioned_docs/version-2.5/k3d/quick-start/install.mdx
+++ b/versioned_docs/version-2.5/k3d/quick-start/install.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: Install
 sidebar_position: 2
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import Tabs from "@theme/Tabs";

--- a/versioned_docs/version-2.5/k3d/quick-start/repositories.mdx
+++ b/versioned_docs/version-2.5/k3d/quick-start/repositories.mdx
@@ -2,7 +2,7 @@
 title: Repositories
 sidebar_position: 3
 description: the git repositories created by the kubefirst platform
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import REPOSITORES from "../../common/repositories.mdx";

--- a/versioned_docs/version-2.5/k3s/credits.mdx
+++ b/versioned_docs/version-2.5/k3s/credits.mdx
@@ -1,7 +1,7 @@
 ---
 title: Credits
 description: credit to all the awesome open source projects
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import CommonCredits from "../common/credits.mdx";

--- a/versioned_docs/version-2.5/k3s/deprovision.mdx
+++ b/versioned_docs/version-2.5/k3s/deprovision.mdx
@@ -5,7 +5,7 @@ sidebar_label: Deprovision
 description: how to deprovision your kubefirst platform
 keywords:
   - aws
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import Deprovision from '../common/deprovision.mdx';

--- a/versioned_docs/version-2.5/k3s/faq.mdx
+++ b/versioned_docs/version-2.5/k3s/faq.mdx
@@ -1,7 +1,7 @@
 ---
 title: FAQ
 description: frequently asked quesitons about the kubefirst platform
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import FAQ from "../common/faq.mdx";

--- a/versioned_docs/version-2.5/k3s/gitops-catalog.mdx
+++ b/versioned_docs/version-2.5/k3s/gitops-catalog.mdx
@@ -5,7 +5,7 @@ sidebar_label: GitOps Catalog
 description: using the kubefirst gitops catalog
 keywords:
   - aws
-image: 'https://docs.kubefirst.io/img/kubefirst.svg'
+image: 'https://kubefirst.konstruct.io/docs/img/kubefirst.svg'
 ---
 
 import GitOpsCatalog from '../common/gitops-catalog.mdx';

--- a/versioned_docs/version-2.5/k3s/overview.mdx
+++ b/versioned_docs/version-2.5/k3s/overview.mdx
@@ -2,7 +2,7 @@
 sidebar_label: Overview
 sidebar_position: 1
 description: an overview of kubefirst on a K3s kubernetes cluster
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import Tabs from "@theme/Tabs";

--- a/versioned_docs/version-2.5/k3s/quick-start/cluster-management.mdx
+++ b/versioned_docs/version-2.5/k3s/quick-start/cluster-management.mdx
@@ -2,7 +2,7 @@
 title: Cluster Management
 sidebar_position: 3
 description: cluster creation and lifecycle management powered by gitops
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import CLUSTERS from "../../common/clusters.mdx";

--- a/versioned_docs/version-2.5/k3s/quick-start/install/cli.mdx
+++ b/versioned_docs/version-2.5/k3s/quick-start/install/cli.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: CLI Installer
 sidebar_position: 3
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import Tabs from "@theme/Tabs";

--- a/versioned_docs/version-2.5/k3s/quick-start/install/ui.mdx
+++ b/versioned_docs/version-2.5/k3s/quick-start/install/ui.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: UI Installer
 sidebar_position: 2
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 <!-- markdownlint-disable MD049 -->

--- a/versioned_docs/version-2.5/k3s/quick-start/repositories.mdx
+++ b/versioned_docs/version-2.5/k3s/quick-start/repositories.mdx
@@ -2,7 +2,7 @@
 title: Repositories
 sidebar_position: 3
 description: the git repositories created by the kubefirst platform
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import REPOSITORES from "../../common/repositories.mdx";

--- a/versioned_docs/version-2.5/vultr/credits.mdx
+++ b/versioned_docs/version-2.5/vultr/credits.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: Credits
 description: credit to all the awesome open source projects
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import CommonCredits from "../common/credits.mdx";

--- a/versioned_docs/version-2.5/vultr/deprovision.mdx
+++ b/versioned_docs/version-2.5/vultr/deprovision.mdx
@@ -5,7 +5,7 @@ sidebar_label: Deprovision
 description: how to deprovision your kubefirst platform
 keywords:
   - aws
-image: 'https://docs.kubefirst.io/img/kubefirst.svg'
+image: 'https://kubefirst.konstruct.io/docs/img/kubefirst.svg'
 ---
 
 import Deprovision from '../common/deprovision.mdx';

--- a/versioned_docs/version-2.5/vultr/faq.mdx
+++ b/versioned_docs/version-2.5/vultr/faq.mdx
@@ -1,7 +1,7 @@
 ---
 title: FAQ
 description: frequently asked quesitons about the kubefirst platform
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import FAQ from "../common/faq.mdx";

--- a/versioned_docs/version-2.5/vultr/gitops-catalog.mdx
+++ b/versioned_docs/version-2.5/vultr/gitops-catalog.mdx
@@ -5,7 +5,7 @@ sidebar_label: GitOps Catalog
 description: using the kubefirst gitops catalog
 keywords:
   - aws
-image: 'https://docs.kubefirst.io/img/kubefirst.svg'
+image: 'https://kubefirst.konstruct.io/docs/img/kubefirst.svg'
 ---
 
 import GitOpsCatalog from '../common/gitops-catalog.mdx';

--- a/versioned_docs/version-2.5/vultr/overview.mdx
+++ b/versioned_docs/version-2.5/vultr/overview.mdx
@@ -3,7 +3,7 @@ hide_title: true
 sidebar_label: Overview
 sidebar_position: 1
 description: an overview of kubefirst on a Vultr kubernetes cluster
-image: 'https://docs.kubefirst.io/img/kubefirst.svg'
+image: 'https://kubefirst.konstruct.io/docs/img/kubefirst.svg'
 ---
 
 import Tabs from '@theme/Tabs';

--- a/versioned_docs/version-2.5/vultr/quick-start/cluster-management.mdx
+++ b/versioned_docs/version-2.5/vultr/quick-start/cluster-management.mdx
@@ -2,7 +2,7 @@
 title: Cluster Management
 sidebar_position: 3
 description: cluster creation and lifecycle management powered by gitops
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 :::note

--- a/versioned_docs/version-2.5/vultr/quick-start/install/cli.mdx
+++ b/versioned_docs/version-2.5/vultr/quick-start/install/cli.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: CLI Installer
 sidebar_position: 3
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import Tabs from "@theme/Tabs";

--- a/versioned_docs/version-2.5/vultr/quick-start/install/ui.mdx
+++ b/versioned_docs/version-2.5/vultr/quick-start/install/ui.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: Console UI
 sidebar_position: 1
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 import UI from "../../../common/ui.mdx";
 

--- a/versioned_docs/version-2.5/vultr/quick-start/repositories.mdx
+++ b/versioned_docs/version-2.5/vultr/quick-start/repositories.mdx
@@ -2,7 +2,7 @@
 title: Repositories
 sidebar_position: 3
 description: the git repositories created by the kubefirst platform
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import REPOSITORES from "../../common/repositories.mdx";

--- a/versioned_docs/version-2.6/akamai/credits.mdx
+++ b/versioned_docs/version-2.6/akamai/credits.mdx
@@ -1,7 +1,7 @@
 ---
 title: Credits
 description: credit to all the awesome open source projects
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import CommonCredits from "../common/credits.mdx";

--- a/versioned_docs/version-2.6/akamai/deprovision.mdx
+++ b/versioned_docs/version-2.6/akamai/deprovision.mdx
@@ -5,7 +5,7 @@ sidebar_label: Deprovision
 description: how to deprovision your kubefirst platform
 keywords:
   - aws
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import Deprovision from '../common/deprovision.mdx';

--- a/versioned_docs/version-2.6/akamai/faq.mdx
+++ b/versioned_docs/version-2.6/akamai/faq.mdx
@@ -1,7 +1,7 @@
 ---
 title: FAQ
 description: frequently asked quesitons about the kubefirst platform
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import FAQ from "../common/faq.mdx";

--- a/versioned_docs/version-2.6/akamai/gitops-catalog.mdx
+++ b/versioned_docs/version-2.6/akamai/gitops-catalog.mdx
@@ -5,7 +5,7 @@ sidebar_label: GitOps Catalog
 description: using the kubefirst gitops catalog
 keywords:
   - aws
-image: 'https://docs.kubefirst.io/img/kubefirst.svg'
+image: 'https://kubefirst.konstruct.io/docs/img/kubefirst.svg'
 ---
 
 import GitOpsCatalog from '../common/gitops-catalog.mdx';

--- a/versioned_docs/version-2.6/akamai/overview.mdx
+++ b/versioned_docs/version-2.6/akamai/overview.mdx
@@ -2,7 +2,7 @@
 sidebar_label: Overview
 sidebar_position: 1
 description: an overview of kubefirst on a Akamai kubernetes cluster
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import Tabs from "@theme/Tabs";

--- a/versioned_docs/version-2.6/akamai/quick-start/cluster-management.mdx
+++ b/versioned_docs/version-2.6/akamai/quick-start/cluster-management.mdx
@@ -2,7 +2,7 @@
 title: Cluster Management
 sidebar_position: 3
 description: cluster creation and lifecycle management powered by gitops
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import CLUSTERS from "../../common/clusters.mdx";

--- a/versioned_docs/version-2.6/akamai/quick-start/install/cli.mdx
+++ b/versioned_docs/version-2.6/akamai/quick-start/install/cli.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: CLI Installer
 sidebar_position: 3
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import Tabs from "@theme/Tabs";

--- a/versioned_docs/version-2.6/akamai/quick-start/install/ui.mdx
+++ b/versioned_docs/version-2.6/akamai/quick-start/install/ui.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: UI Installer
 sidebar_position: 2
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 import UI from "../../../common/ui.mdx";
 

--- a/versioned_docs/version-2.6/akamai/quick-start/repositories.mdx
+++ b/versioned_docs/version-2.6/akamai/quick-start/repositories.mdx
@@ -2,7 +2,7 @@
 title: Repositories
 sidebar_position: 3
 description: the git repositories created by the kubefirst platform
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import REPOSITORES from "../../common/repositories.mdx";

--- a/versioned_docs/version-2.6/aws/credits.mdx
+++ b/versioned_docs/version-2.6/aws/credits.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: Credits
 description: how to destroy your kubefirst platform
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import Credits from "../common/credits.mdx";

--- a/versioned_docs/version-2.6/aws/deprovision.mdx
+++ b/versioned_docs/version-2.6/aws/deprovision.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: Deprovision
 description: how to destroy your kubefirst platform
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import Deprovision from '../common/deprovision.mdx';

--- a/versioned_docs/version-2.6/aws/faq.mdx
+++ b/versioned_docs/version-2.6/aws/faq.mdx
@@ -1,7 +1,7 @@
 ---
 title: FAQ
 description: frequently asked quesitons about the platform
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import FAQ from "../common/faq.mdx";

--- a/versioned_docs/version-2.6/aws/gitops-catalog.mdx
+++ b/versioned_docs/version-2.6/aws/gitops-catalog.mdx
@@ -5,7 +5,7 @@ sidebar_label: GitOps Catalog
 description: using the kubefirst gitops catalog
 keywords:
   - aws
-image: 'https://docs.kubefirst.io/img/kubefirst.svg'
+image: 'https://kubefirst.konstruct.io/docs/img/kubefirst.svg'
 ---
 
 import GitOpsCatalog from '../common/gitops-catalog.mdx';

--- a/versioned_docs/version-2.6/aws/overview.mdx
+++ b/versioned_docs/version-2.6/aws/overview.mdx
@@ -3,7 +3,7 @@ hide_title: true
 sidebar_label: Overview
 sidebar_position: 1
 description: an overview of the kubefirst platform
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import Tabs from "@theme/Tabs";

--- a/versioned_docs/version-2.6/aws/quick-start/cluster-management.mdx
+++ b/versioned_docs/version-2.6/aws/quick-start/cluster-management.mdx
@@ -2,7 +2,7 @@
 title: Cluster Management
 sidebar_position: 3
 description: cluster creation and lifecycle management powered by gitops
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 :::note

--- a/versioned_docs/version-2.6/aws/quick-start/iac-and-app-delivery.mdx
+++ b/versioned_docs/version-2.6/aws/quick-start/iac-and-app-delivery.mdx
@@ -3,7 +3,7 @@ hide_title: true
 sidebar_label: IAC and App Delivery
 sidebar_position: 3
 description: an overview of the kubefirst platform on aws elastic kubernetes service (EKS)
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 ## Step 1: Console UI

--- a/versioned_docs/version-2.6/aws/quick-start/install/cli.mdx
+++ b/versioned_docs/version-2.6/aws/quick-start/install/cli.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: CLI Installer
 sidebar_position: 3
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import Tabs from "@theme/Tabs";

--- a/versioned_docs/version-2.6/aws/quick-start/install/ui.mdx
+++ b/versioned_docs/version-2.6/aws/quick-start/install/ui.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: Console UI
 sidebar_position: 1
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 import UI from "../../../common/ui.mdx";
 

--- a/versioned_docs/version-2.6/aws/quick-start/repositories.mdx
+++ b/versioned_docs/version-2.6/aws/quick-start/repositories.mdx
@@ -2,7 +2,7 @@
 title: Repositories
 sidebar_position: 3
 description: the git repositories created by the kubefirst platform
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import REPOSITORES from "../../common/repositories.mdx";

--- a/versioned_docs/version-2.6/civo/credits.mdx
+++ b/versioned_docs/version-2.6/civo/credits.mdx
@@ -1,7 +1,7 @@
 ---
 title: Credits
 description: credit to all the awesome open source projects
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import CommonCredits from "../common/credits.mdx";

--- a/versioned_docs/version-2.6/civo/deprovision.mdx
+++ b/versioned_docs/version-2.6/civo/deprovision.mdx
@@ -5,7 +5,7 @@ sidebar_label: Deprovision
 description: how to deprovision your kubefirst platform
 keywords:
   - aws
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import Deprovision from '../common/deprovision.mdx';

--- a/versioned_docs/version-2.6/civo/faq.mdx
+++ b/versioned_docs/version-2.6/civo/faq.mdx
@@ -1,7 +1,7 @@
 ---
 title: FAQ
 description: frequently asked quesitons about the kubefirst platform
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import FAQ from "../common/faq.mdx";

--- a/versioned_docs/version-2.6/civo/gitops-catalog.mdx
+++ b/versioned_docs/version-2.6/civo/gitops-catalog.mdx
@@ -5,7 +5,7 @@ sidebar_label: GitOps Catalog
 description: using the kubefirst gitops catalog
 keywords:
   - aws
-image: 'https://docs.kubefirst.io/img/kubefirst.svg'
+image: 'https://kubefirst.konstruct.io/docs/img/kubefirst.svg'
 ---
 
 import GitOpsCatalog from '../common/gitops-catalog.mdx';

--- a/versioned_docs/version-2.6/civo/overview.mdx
+++ b/versioned_docs/version-2.6/civo/overview.mdx
@@ -2,7 +2,7 @@
 sidebar_label: Overview
 sidebar_position: 1
 description: an overview of kubefirst on a civo kubernetes cluster
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import Tabs from "@theme/Tabs";

--- a/versioned_docs/version-2.6/civo/quick-start/cluster-management.mdx
+++ b/versioned_docs/version-2.6/civo/quick-start/cluster-management.mdx
@@ -2,7 +2,7 @@
 title: Cluster Management
 sidebar_position: 3
 description: cluster creation and lifecycle management powered by gitops
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import CLUSTERS from "../../common/clusters.mdx";

--- a/versioned_docs/version-2.6/civo/quick-start/install/cli.mdx
+++ b/versioned_docs/version-2.6/civo/quick-start/install/cli.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: CLI Installer
 sidebar_position: 3
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import Tabs from "@theme/Tabs";

--- a/versioned_docs/version-2.6/civo/quick-start/install/marketplace.mdx
+++ b/versioned_docs/version-2.6/civo/quick-start/install/marketplace.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: Civo Marketplace
 sidebar_position: 1
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 # Install kubefirst using the Civo Marketplace

--- a/versioned_docs/version-2.6/civo/quick-start/install/ui.mdx
+++ b/versioned_docs/version-2.6/civo/quick-start/install/ui.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: UI Installer
 sidebar_position: 2
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 import UI from "../../../common/ui.mdx";
 

--- a/versioned_docs/version-2.6/civo/quick-start/repositories.mdx
+++ b/versioned_docs/version-2.6/civo/quick-start/repositories.mdx
@@ -2,7 +2,7 @@
 title: Repositories
 sidebar_position: 3
 description: the git repositories created by the kubefirst platform
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import REPOSITORES from "../../common/repositories.mdx";

--- a/versioned_docs/version-2.6/common/deprovision.mdx
+++ b/versioned_docs/version-2.6/common/deprovision.mdx
@@ -27,7 +27,7 @@ If you are coming from a cloud marketplace, and didn't use the kubefirst CLI, yo
 brew install konstructio/taps/kubefirst
 ```
 
-More information in the [installation steps from our documentation](https://docs.kubefirst.io/next/aws/quick-start/install/cli#local-prerequisites).
+More information in the [installation steps from our documentation](https://kubefirst.konstruct.io/docs/next/aws/quick-start/install/cli#local-prerequisites).
 
 ### Kubernetes CLI
 

--- a/versioned_docs/version-2.6/common/repositories.mdx
+++ b/versioned_docs/version-2.6/common/repositories.mdx
@@ -2,7 +2,7 @@
 title: Repositories
 sidebar_position: 2
 description: the git repositories created by the kubefirst platform
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import Tabs from "@theme/Tabs";

--- a/versioned_docs/version-2.6/do/credits.mdx
+++ b/versioned_docs/version-2.6/do/credits.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: Credits
 description: credit to all the awesome open source projects
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import CommonCredits from "../common/credits.mdx";

--- a/versioned_docs/version-2.6/do/deprovision.mdx
+++ b/versioned_docs/version-2.6/do/deprovision.mdx
@@ -5,7 +5,7 @@ sidebar_label: Deprovision
 description: how to deprovision your kubefirst platform
 keywords:
   - aws
-image: 'https://docs.kubefirst.io/img/kubefirst.svg'
+image: 'https://kubefirst.konstruct.io/docs/img/kubefirst.svg'
 ---
 
 import Deprovision from '../common/deprovision.mdx';

--- a/versioned_docs/version-2.6/do/faq.mdx
+++ b/versioned_docs/version-2.6/do/faq.mdx
@@ -1,7 +1,7 @@
 ---
 title: FAQ
 description: frequently asked quesitons about the kubefirst platform
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import FAQ from "../common/faq.mdx";

--- a/versioned_docs/version-2.6/do/gitops-catalog.mdx
+++ b/versioned_docs/version-2.6/do/gitops-catalog.mdx
@@ -5,7 +5,7 @@ sidebar_label: GitOps Catalog
 description: using the kubefirst gitops catalog
 keywords:
   - aws
-image: 'https://docs.kubefirst.io/img/kubefirst.svg'
+image: 'https://kubefirst.konstruct.io/docs/img/kubefirst.svg'
 ---
 
 import GitOpsCatalog from '../common/gitops-catalog.mdx';

--- a/versioned_docs/version-2.6/do/overview.mdx
+++ b/versioned_docs/version-2.6/do/overview.mdx
@@ -3,7 +3,7 @@ hide_title: true
 sidebar_label: Overview
 sidebar_position: 1
 description: an overview of kubefirst on a DigitalOcean kubernetes cluster
-image: 'https://docs.kubefirst.io/img/kubefirst.svg'
+image: 'https://kubefirst.konstruct.io/docs/img/kubefirst.svg'
 ---
 
 import Tabs from '@theme/Tabs';

--- a/versioned_docs/version-2.6/do/quick-start/cluster-management.mdx
+++ b/versioned_docs/version-2.6/do/quick-start/cluster-management.mdx
@@ -2,7 +2,7 @@
 title: Cluster Management
 sidebar_position: 3
 description: cluster creation and lifecycle management powered by gitops
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 :::note

--- a/versioned_docs/version-2.6/do/quick-start/install/cli.mdx
+++ b/versioned_docs/version-2.6/do/quick-start/install/cli.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: CLI Installer
 sidebar_position: 3
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import Tabs from "@theme/Tabs";

--- a/versioned_docs/version-2.6/do/quick-start/install/marketplace.mdx
+++ b/versioned_docs/version-2.6/do/quick-start/install/marketplace.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: DigitalOcean Marketplace
 sidebar_position: 1
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 # Install kubefirst using the DigitalOcean Marketplace

--- a/versioned_docs/version-2.6/do/quick-start/install/ui.mdx
+++ b/versioned_docs/version-2.6/do/quick-start/install/ui.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: Console UI
 sidebar_position: 1
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import UI from "../../../common/ui.mdx";

--- a/versioned_docs/version-2.6/do/quick-start/repositories.mdx
+++ b/versioned_docs/version-2.6/do/quick-start/repositories.mdx
@@ -2,7 +2,7 @@
 title: Repositories
 sidebar_position: 3
 description: the git repositories created by the kubefirst platform
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import REPOSITORES from "../../common/repositories.mdx";

--- a/versioned_docs/version-2.6/gcp/credits.mdx
+++ b/versioned_docs/version-2.6/gcp/credits.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: Credits
 description: credit to all the awesome open source projects
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import CommonCredits from "../common/credits.mdx";

--- a/versioned_docs/version-2.6/gcp/deprovision.mdx
+++ b/versioned_docs/version-2.6/gcp/deprovision.mdx
@@ -5,7 +5,7 @@ sidebar_label: Deprovision
 description: how to deprovision your kubefirst platform
 keywords:
   - aws
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import Deprovision from '../common/deprovision.mdx';

--- a/versioned_docs/version-2.6/gcp/faq.mdx
+++ b/versioned_docs/version-2.6/gcp/faq.mdx
@@ -1,7 +1,7 @@
 ---
 title: FAQ
 description: frequently asked quesitons about the kubefirst platform
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import FAQ from "../common/faq.mdx";

--- a/versioned_docs/version-2.6/gcp/gitops-catalog.mdx
+++ b/versioned_docs/version-2.6/gcp/gitops-catalog.mdx
@@ -5,7 +5,7 @@ sidebar_label: GitOps Catalog
 description: using the kubefirst gitops catalog
 keywords:
   - aws
-image: 'https://docs.kubefirst.io/img/kubefirst.svg'
+image: 'https://kubefirst.konstruct.io/docs/img/kubefirst.svg'
 ---
 
 import GitOpsCatalog from '../common/gitops-catalog.mdx';

--- a/versioned_docs/version-2.6/gcp/overview.mdx
+++ b/versioned_docs/version-2.6/gcp/overview.mdx
@@ -3,7 +3,7 @@ hide_title: true
 sidebar_label: Overview
 sidebar_position: 1
 description: an overview of kubefirst on a Google Cloud kubernetes cluster
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 
 ---
 import Tabs from "@theme/Tabs";

--- a/versioned_docs/version-2.6/gcp/quick-start/cluster-management.mdx
+++ b/versioned_docs/version-2.6/gcp/quick-start/cluster-management.mdx
@@ -2,7 +2,7 @@
 title: Cluster Management
 sidebar_position: 3
 description: cluster creation and lifecycle management powered by gitops
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 :::note

--- a/versioned_docs/version-2.6/gcp/quick-start/install/cli.mdx
+++ b/versioned_docs/version-2.6/gcp/quick-start/install/cli.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: CLI Installer
 sidebar_position: 3
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import Tabs from "@theme/Tabs";

--- a/versioned_docs/version-2.6/gcp/quick-start/install/ui.mdx
+++ b/versioned_docs/version-2.6/gcp/quick-start/install/ui.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: Console UI
 sidebar_position: 1
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 import UI from "../../../common/ui.mdx";
 

--- a/versioned_docs/version-2.6/gcp/quick-start/repositories.mdx
+++ b/versioned_docs/version-2.6/gcp/quick-start/repositories.mdx
@@ -2,7 +2,7 @@
 title: Repositories
 sidebar_position: 3
 description: the git repositories created by the kubefirst platform
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import REPOSITORES from "../../common/repositories.mdx";

--- a/versioned_docs/version-2.6/k3d/credits.mdx
+++ b/versioned_docs/version-2.6/k3d/credits.mdx
@@ -3,7 +3,7 @@ hide_title: true
 sidebar_label: Credits
 sidebar_position: 4
 description: Credits for the awesome open source we use
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import Credits from "../common/credits.mdx";

--- a/versioned_docs/version-2.6/k3d/deprovision.mdx
+++ b/versioned_docs/version-2.6/k3d/deprovision.mdx
@@ -3,7 +3,7 @@ hide_title: true
 sidebar_label: Deprovision
 sidebar_position: 2
 description: how to deprovision your kubefirst platform
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 # Deprovision

--- a/versioned_docs/version-2.6/k3d/faq.mdx
+++ b/versioned_docs/version-2.6/k3d/faq.mdx
@@ -1,7 +1,7 @@
 ---
 title: FAQ
 description: frequently asked quesitons about the kubefirst platform
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import FAQ from "../common/faq.mdx";

--- a/versioned_docs/version-2.6/k3d/gitops-catalog.mdx
+++ b/versioned_docs/version-2.6/k3d/gitops-catalog.mdx
@@ -5,7 +5,7 @@ sidebar_label: GitOps Catalog
 description: using the kubefirst gitops catalog
 keywords:
   - aws
-image: 'https://docs.kubefirst.io/img/kubefirst.svg'
+image: 'https://kubefirst.konstruct.io/docs/img/kubefirst.svg'
 ---
 
 import GitOpsCatalog from '../common/gitops-catalog.mdx';

--- a/versioned_docs/version-2.6/k3d/overview.mdx
+++ b/versioned_docs/version-2.6/k3d/overview.mdx
@@ -3,7 +3,7 @@ hide_title: true
 sidebar_label: Overview
 sidebar_position: 1
 description: an overview of the kubefirst platform
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import Tabs from "@theme/Tabs";

--- a/versioned_docs/version-2.6/k3d/quick-start/install.mdx
+++ b/versioned_docs/version-2.6/k3d/quick-start/install.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: Install
 sidebar_position: 2
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import Tabs from "@theme/Tabs";

--- a/versioned_docs/version-2.6/k3d/quick-start/repositories.mdx
+++ b/versioned_docs/version-2.6/k3d/quick-start/repositories.mdx
@@ -2,7 +2,7 @@
 title: Repositories
 sidebar_position: 3
 description: the git repositories created by the kubefirst platform
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import REPOSITORES from "../../common/repositories.mdx";

--- a/versioned_docs/version-2.6/k3s/credits.mdx
+++ b/versioned_docs/version-2.6/k3s/credits.mdx
@@ -1,7 +1,7 @@
 ---
 title: Credits
 description: credit to all the awesome open source projects
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import CommonCredits from "../common/credits.mdx";

--- a/versioned_docs/version-2.6/k3s/deprovision.mdx
+++ b/versioned_docs/version-2.6/k3s/deprovision.mdx
@@ -5,7 +5,7 @@ sidebar_label: Deprovision
 description: how to deprovision your kubefirst platform
 keywords:
   - aws
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import Deprovision from '../common/deprovision.mdx';

--- a/versioned_docs/version-2.6/k3s/faq.mdx
+++ b/versioned_docs/version-2.6/k3s/faq.mdx
@@ -1,7 +1,7 @@
 ---
 title: FAQ
 description: frequently asked quesitons about the kubefirst platform
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import FAQ from "../common/faq.mdx";

--- a/versioned_docs/version-2.6/k3s/gitops-catalog.mdx
+++ b/versioned_docs/version-2.6/k3s/gitops-catalog.mdx
@@ -5,7 +5,7 @@ sidebar_label: GitOps Catalog
 description: using the kubefirst gitops catalog
 keywords:
   - aws
-image: 'https://docs.kubefirst.io/img/kubefirst.svg'
+image: 'https://kubefirst.konstruct.io/docs/img/kubefirst.svg'
 ---
 
 import GitOpsCatalog from '../common/gitops-catalog.mdx';

--- a/versioned_docs/version-2.6/k3s/overview.mdx
+++ b/versioned_docs/version-2.6/k3s/overview.mdx
@@ -2,7 +2,7 @@
 sidebar_label: Overview
 sidebar_position: 1
 description: an overview of kubefirst on a K3s kubernetes cluster
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import Tabs from "@theme/Tabs";

--- a/versioned_docs/version-2.6/k3s/quick-start/cluster-management.mdx
+++ b/versioned_docs/version-2.6/k3s/quick-start/cluster-management.mdx
@@ -2,7 +2,7 @@
 title: Cluster Management
 sidebar_position: 3
 description: cluster creation and lifecycle management powered by gitops
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import CLUSTERS from "../../common/clusters.mdx";

--- a/versioned_docs/version-2.6/k3s/quick-start/install/cli.mdx
+++ b/versioned_docs/version-2.6/k3s/quick-start/install/cli.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: CLI Installer
 sidebar_position: 3
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import Tabs from "@theme/Tabs";

--- a/versioned_docs/version-2.6/k3s/quick-start/install/ui.mdx
+++ b/versioned_docs/version-2.6/k3s/quick-start/install/ui.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: UI Installer
 sidebar_position: 2
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 <!-- markdownlint-disable MD049 -->

--- a/versioned_docs/version-2.6/k3s/quick-start/repositories.mdx
+++ b/versioned_docs/version-2.6/k3s/quick-start/repositories.mdx
@@ -2,7 +2,7 @@
 title: Repositories
 sidebar_position: 3
 description: the git repositories created by the kubefirst platform
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import REPOSITORES from "../../common/repositories.mdx";

--- a/versioned_docs/version-2.6/vultr/credits.mdx
+++ b/versioned_docs/version-2.6/vultr/credits.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: Credits
 description: credit to all the awesome open source projects
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import CommonCredits from "../common/credits.mdx";

--- a/versioned_docs/version-2.6/vultr/deprovision.mdx
+++ b/versioned_docs/version-2.6/vultr/deprovision.mdx
@@ -5,7 +5,7 @@ sidebar_label: Deprovision
 description: how to deprovision your kubefirst platform
 keywords:
   - aws
-image: 'https://docs.kubefirst.io/img/kubefirst.svg'
+image: 'https://kubefirst.konstruct.io/docs/img/kubefirst.svg'
 ---
 
 import Deprovision from '../common/deprovision.mdx';

--- a/versioned_docs/version-2.6/vultr/faq.mdx
+++ b/versioned_docs/version-2.6/vultr/faq.mdx
@@ -1,7 +1,7 @@
 ---
 title: FAQ
 description: frequently asked quesitons about the kubefirst platform
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import FAQ from "../common/faq.mdx";

--- a/versioned_docs/version-2.6/vultr/gitops-catalog.mdx
+++ b/versioned_docs/version-2.6/vultr/gitops-catalog.mdx
@@ -5,7 +5,7 @@ sidebar_label: GitOps Catalog
 description: using the kubefirst gitops catalog
 keywords:
   - aws
-image: 'https://docs.kubefirst.io/img/kubefirst.svg'
+image: 'https://kubefirst.konstruct.io/docs/img/kubefirst.svg'
 ---
 
 import GitOpsCatalog from '../common/gitops-catalog.mdx';

--- a/versioned_docs/version-2.6/vultr/overview.mdx
+++ b/versioned_docs/version-2.6/vultr/overview.mdx
@@ -3,7 +3,7 @@ hide_title: true
 sidebar_label: Overview
 sidebar_position: 1
 description: an overview of kubefirst on a Vultr kubernetes cluster
-image: 'https://docs.kubefirst.io/img/kubefirst.svg'
+image: 'https://kubefirst.konstruct.io/docs/img/kubefirst.svg'
 ---
 
 import Tabs from '@theme/Tabs';

--- a/versioned_docs/version-2.6/vultr/quick-start/cluster-management.mdx
+++ b/versioned_docs/version-2.6/vultr/quick-start/cluster-management.mdx
@@ -2,7 +2,7 @@
 title: Cluster Management
 sidebar_position: 3
 description: cluster creation and lifecycle management powered by gitops
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 :::note

--- a/versioned_docs/version-2.6/vultr/quick-start/install/cli.mdx
+++ b/versioned_docs/version-2.6/vultr/quick-start/install/cli.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: CLI Installer
 sidebar_position: 3
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import Tabs from "@theme/Tabs";

--- a/versioned_docs/version-2.6/vultr/quick-start/install/ui.mdx
+++ b/versioned_docs/version-2.6/vultr/quick-start/install/ui.mdx
@@ -2,7 +2,7 @@
 hide_title: true
 sidebar_label: Console UI
 sidebar_position: 1
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 import UI from "../../../common/ui.mdx";
 

--- a/versioned_docs/version-2.6/vultr/quick-start/repositories.mdx
+++ b/versioned_docs/version-2.6/vultr/quick-start/repositories.mdx
@@ -2,7 +2,7 @@
 title: Repositories
 sidebar_position: 3
 description: the git repositories created by the kubefirst platform
-image: "https://docs.kubefirst.io/img/kubefirst.svg"
+image: "https://kubefirst.konstruct.io/docs/img/kubefirst.svg"
 ---
 
 import REPOSITORES from "../../common/repositories.mdx";


### PR DESCRIPTION
## Description
PR updates `docs.kubefirst.io` to `kubefirst.konstruct.io/docs'

## Related Issue(s)
NA

## How to test
```
npm start
```
