### PR TITLE
chore: add script to delete a version of the docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -176,6 +176,13 @@ You'll be presented with a menu giving you the opportunity to select the files y
 
 > Note that it is copying the entire file, so it will overwrite the content to the targeted version. We may support updating only changes content in the future.
 
+We also provide a script to delete all the `versioned_docs` for a specific version. This is useful when updating documentation for a patch release.
+
+```shell
+npm run remove_version <version>
+npm run docusaurus docs:version <version>
+```
+
 ### Versioning
 
 Docusaurus manages [documentation versions](https://docusaurus.io/docs/versioning), which we started to use since the v2.0.0 release. It means that every time we release a new version (minor or major only) of Kubefirst, we need to freeze the `next` documentation, meaning the documentation updated in the `docs` directory, into a versioned one inside the `versioned_docs\version-X.X` folder. To generate a new version, run the [Create a new docs version](https://github.com/konstructio/docs/actions/workflows/release.yml) GitHub Actions workflow, and enter the desired version number. It will create a pull request with the new version for you.

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",
     "serve": "docusaurus serve",
+    "remove_version": "node ./tools/remove_version.mjs",
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids"
   },

--- a/tools/remove_version.mjs
+++ b/tools/remove_version.mjs
@@ -1,0 +1,58 @@
+import fs from 'fs/promises';
+import path from 'path';
+
+const rootPath = path.join(import.meta.dirname, '..');
+
+async function removeFromVersionsJSON(version) {
+    const versionsFile = path.join(rootPath, 'versions.json');
+
+    console.log(`Removing version ${version} from ${versionsFile}`);
+
+    const versions = JSON.parse(await fs.readFile(versionsFile, 'utf-8'));
+
+    if (!versions.includes(version)) {
+        throw new Error('Unknown version');
+    }
+
+    const newVersions = versions.filter((v) => v !== version);
+
+    await fs.writeFile(versionsFile, `${JSON.stringify(newVersions, null, 2)}\n`, 'utf-8');
+}
+
+async function removeVersionedDocs(version) {
+    const directory = path.join(rootPath, 'versioned_docs', `version-${version}`);
+
+    console.log(`Deleting ${directory}`);
+
+    await fs.rm(directory, {
+        recursive: true,
+        force: true,
+    });
+}
+
+async function removeVersionedSidebar(version) {
+    const file = path.join(rootPath, 'versioned_sidebars', `version-${version}-sidebars.json`);
+
+    console.log(`Deleting ${file}`);
+
+    await fs.rm(file);
+}
+
+async function main() {
+    const [, , version] = process.argv;
+
+    if (!version) {
+        throw new Error('Version not set');
+    }
+
+    await removeFromVersionsJSON(version);
+    await removeVersionedDocs(version);
+    await removeVersionedSidebar(version);
+
+    console.log(`Version ${version} is removed`)
+}
+
+main().catch(err => {
+    console.log(err.stack);
+    process.exit(1);
+});


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This is to make it easier to update docs. We use this when updating the docs for a patch release.

## Related Issue(s)
<!-- List the issue(s) this PR solves. An issue should be raised before creating a PR -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
```shell
npm run remove_version 2.7
npm run docusaurus docs:version 2.7
```

You will now only see the actual differences in what's changed.
