### PR TITLE
fix: use full path for the banner image

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -99,7 +99,7 @@ const config = {
       ],
       announcementBar: {
         id: 'announcement',
-        content: '<img src="img/megaphone.svg">Please change your Homebrew tap by running <code>brew uninstall kubefirst; brew install konstructio/taps/kubefirst</code>',
+        content: '<img src="/docs/img/megaphone.svg">Please change your Homebrew tap by running <code>brew uninstall kubefirst; brew install konstructio/taps/kubefirst</code>',
         backgroundColor: '#FA9247',
         textColor: '#3B4954',
         isCloseable: true,


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
A thing I noticed is that the megaphone image appears if you start at the doc root, but not if you start at a mid-page (eg, if you come to the docs from Google)

- Go to the [homepage](https://kubefirst.konstruct.io/docs) and you see it
  ![image](https://github.com/user-attachments/assets/36e5ec35-e358-4069-86c2-c00444a2bc00)
- Go to a landing page (eg https://kubefirst.konstruct.io/docs/azure/overview/) and you don't
  ![image](https://github.com/user-attachments/assets/bbe40fa5-bd88-41dd-b62a-e3fbc47e3e71)


(If you have already dismissed the alert, you'll need to clear your `localstorage`)

## Related Issue(s)
<!-- List the issue(s) this PR solves. An issue should be raised before creating a PR -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
Run `npm start`