### PR TITLE
Note specific multi-cluster differences between k3d and other clouds

### DIFF
--- a/docs/akamai/overview.mdx
+++ b/docs/akamai/overview.mdx
@@ -35,7 +35,10 @@ Akamai is in beta. Use at your own risks.
 :::
 
 The Akamai provisioning process will:
-<CommonProvisionProcess firstitem="Create a Kubernetes management cluster in the Akamai cloud."/>
+<CommonProvisionProcess 
+    firstitem="Create a Kubernetes management cluster in the Akamai cloud."
+    seconditem="Create three virtual workload clusters for each default environment (development, staging & production)."
+/>
 
 <Tabs groupId="git_provider" defaultValue="github" queryString>
   <TabItem attributes={{ className: styles.github }} value="github" label={ <GitHubLogo /> }>

--- a/docs/aws/overview.mdx
+++ b/docs/aws/overview.mdx
@@ -25,7 +25,11 @@ import GitLabLogo from '../common/components/GitLabLogo.jsx'
 # Overview
 
 The AWS provisioning process will:
-<CommonProvisionProcess firstitem="Create a Kubernetes management cluster in the AWS cloud."/>
+<CommonProvisionProcess 
+    firstitem="Create a Kubernetes management cluster in the AWS cloud."
+    seconditem="Create three virtual workload clusters for each default environment (development, staging & production)."
+/>
+
 
 <Tabs groupId="git_provider" defaultValue="github" queryString>
   <TabItem attributes={{ className: styles.github }} value="github" label={ <GitHubLogo /> }>

--- a/docs/azure/overview.mdx
+++ b/docs/azure/overview.mdx
@@ -29,7 +29,11 @@ Azure is in beta. Use at your own risk.
 :::
 
 The Azure provisioning process will:
-<CommonProvisionProcess firstitem="Create a Kubernetes management cluster in the Azure cloud."/>
+<CommonProvisionProcess 
+    firstitem="Create a Kubernetes management cluster in the Azure cloud."
+    seconditem="Create three virtual workload clusters for each default environment (development, staging & production)."
+/>
+
 
 <Tabs groupId="git_provider" defaultValue="github" queryString>
   <TabItem attributes={{ className: styles.github }} value="github" label={ <GitHubLogo /> }>

--- a/docs/civo/overview.mdx
+++ b/docs/civo/overview.mdx
@@ -25,7 +25,11 @@ import GitLabLogo from '../common/components/GitLabLogo.jsx'
 # Overview
 
 The Civo provisioning process will:
-<CommonProvisionProcess firstitem="Create a Kubernetes management cluster in the Civo cloud."/>
+<CommonProvisionProcess 
+    firstitem="Create a Kubernetes management cluster in the Civo cloud."
+    seconditem="Create three virtual workload clusters for each default environment (development, staging & production)."
+/>
+
 
 <Tabs groupId="git_provider" defaultValue="github" queryString>
   <TabItem attributes={{ className: styles.github }} value="github" label={ <GitHubLogo /> }>

--- a/docs/common/partials/common/_provision-process.mdx
+++ b/docs/common/partials/common/_provision-process.mdx
@@ -1,4 +1,5 @@
 - {props.firstitem}
+- {props.seconditem}
 - Create a `gitops` Git repository from our [gitops-template](https://github.com/kubefirst/gitops-template) and store it in your selected Git provider.
 - Install Argo CD bootstrapped against your `gitops` repository so your repository powers the platform, and become your source of truth.
 - Install all the platform applications using GitOps (from the `/registry` folder in the `gitops` repository).

--- a/docs/do/overview.mdx
+++ b/docs/do/overview.mdx
@@ -26,7 +26,11 @@ import GitLabLogo from '../common/components/GitLabLogo.jsx'
 # Overview
 
 The DigitalOcean provisioning process will:
-<CommonProvisionProcess firstitem="Create a Kubernetes management cluster in the DigitalOcean cloud."/>
+<CommonProvisionProcess 
+    firstitem="Create a Kubernetes management cluster in the DigitalOcean cloud."
+    seconditem="Create three virtual workload clusters for each default environment (development, staging & production)."
+/>
+
 
 <Tabs groupId="git_provider" defaultValue="github" queryString>
   <TabItem attributes={{ className: styles.github }} value="github" label={ <GitHubLogo /> }>

--- a/docs/gcp/overview.mdx
+++ b/docs/gcp/overview.mdx
@@ -30,7 +30,11 @@ Google Cloud is in beta. Use at your own risks.
 :::
 
 The Google Cloud provisioning process will:
-<CommonProvisionProcess firstitem="Create a Kubernetes management cluster in Google Cloud."/>
+<CommonProvisionProcess 
+    firstitem="Create a Kubernetes management cluster in Google cloud."
+    seconditem="Create three virtual workload clusters for each default environment (development, staging & production)."
+/>
+
 
 <Tabs groupId="git_provider" defaultValue="github" queryString>
   <TabItem attributes={{ className: styles.github }} value="github" label={ <GitHubLogo /> }>

--- a/docs/k3d/overview.mdx
+++ b/docs/k3d/overview.mdx
@@ -25,7 +25,10 @@ import GitLabLogo from '../common/components/GitLabLogo.jsx'
 # Overview
 
 The k3d provisioning process will:
-<CommonProvisionProcess firstitem="Create a multinode k3d Kubernetes cluster on your localhost." />
+<CommonProvisionProcess 
+    firstitem="Create a multinode k3d Kubernetes cluster on your localhost."
+    seconditem="Create three namespaces for each default environment (development, staging & production). Note: This all runs in a single, multi-node cluster unlike other public clouds"
+/>
 
 <Tabs groupId="git_provider" defaultValue="github" queryString>
   <TabItem attributes={{ className: styles.github }} value="github" label={ <GitHubLogo /> }>

--- a/docs/k3s/overview.mdx
+++ b/docs/k3s/overview.mdx
@@ -31,7 +31,10 @@ K3s is in beta. Use at your own risks.
 :::
 
 The K3s provisioning process will:
-<CommonProvisionProcess firstitem="Create a Kubernetes management cluster with K3s."/>
+<CommonProvisionProcess 
+    firstitem="Create a Kubernetes management cluster with K3s."
+    seconditem="Create three virtual workload clusters for each default environment (development, staging & production)."
+/>
 
 <Tabs groupId="git_provider" defaultValue="github" queryString>
   <TabItem value="github" attributes={{ className: styles.github }} label={ <GitHubLogo /> }>

--- a/docs/vultr/overview.mdx
+++ b/docs/vultr/overview.mdx
@@ -32,7 +32,11 @@ Vultr is in beta. It is quite stable, but use at your own risks.
 :::
 
 The Vultr provisioning process will:
-<CommonProvisionProcess firstitem="Create a Kubernetes management cluster in the Vultr cloud."/>
+<CommonProvisionProcess 
+    firstitem="Create a Kubernetes management cluster in the Vultr cloud."
+    seconditem="Create three virtual workload clusters for each default environment (development, staging & production)."
+/>
+
 
 <Tabs groupId="git_provider" defaultValue="github" queryString>
   <TabItem attributes={{ className: styles.github }} value="github" label={ <GitHubLogo /> }>

--- a/versioned_docs/version-2.3/aws/overview.mdx
+++ b/versioned_docs/version-2.3/aws/overview.mdx
@@ -22,7 +22,10 @@ import AWSLogo from '../img/aws/logo.svg';
 # Overview
 
 The AWS provisioning process will:
-<CommonProvisionProcess firstitem="Create a Kubernetes management cluster in the AWS cloud."/>
+<CommonProvisionProcess 
+    firstitem="Create a Kubernetes management cluster in the AWS cloud." 
+    seconditem="Create three virtual workload clusters for each default environment (development, staging & production)."
+/>
 
 <Tabs groupId="git_provider" defaultValue="github" queryString>
   <TabItem attributes={{ className: styles.github }} value="github" label={ <div className="git-tab"><img src="https://assets.kubefirst.com/console/github.svg" alt="GitHub logo" /><span>GitHub</span></div> }>

--- a/versioned_docs/version-2.3/civo/overview.mdx
+++ b/versioned_docs/version-2.3/civo/overview.mdx
@@ -22,7 +22,10 @@ import CivoLogo from '../img/civo/logo.svg';
 # Overview
 
 The Civo provisioning process will:
-<CommonProvisionProcess firstitem="Create a Kubernetes management cluster in the Civo cloud."/>
+<CommonProvisionProcess 
+    firstitem="Create a Kubernetes management cluster in the Civo cloud." 
+    seconditem="Create three virtual workload clusters for each default environment (development, staging & production)."
+/>
 
 <Tabs groupId="git_provider" defaultValue="github" queryString>
   <TabItem attributes={{ className: styles.github }} value="github" label={ <div className="git-tab"><img src="https://assets.kubefirst.com/console/github.svg" alt="GitHub logo" /><span>GitHub</span></div> }>

--- a/versioned_docs/version-2.3/common/partials/common/_provision-process.mdx
+++ b/versioned_docs/version-2.3/common/partials/common/_provision-process.mdx
@@ -1,5 +1,5 @@
 - {props.firstitem}
-- Create three virtual workload clusters for each default environment (development, staging & production).
+- {props.seconditem}
 - Create a `gitops` Git repository from our [gitops-template](https://github.com/kubefirst/gitops-template) and store it in your selected Git provider.
 - Install Argo CD bootstrapped against your `gitops` repository so your repository powers the platform, and become your source of truth.
 - Install all the platform applications using GitOps (from the `/registry` folder in the `gitops` repository).

--- a/versioned_docs/version-2.3/do/overview.mdx
+++ b/versioned_docs/version-2.3/do/overview.mdx
@@ -23,7 +23,10 @@ import DOLogo from '../img/do/logo.svg';
 # Overview
 
 The DigitalOcean provisioning process will:
-<CommonProvisionProcess firstitem="Create a Kubernetes management cluster in the DigitalOcean cloud."/>
+<CommonProvisionProcess 
+    firstitem="Create a Kubernetes management cluster in the DigitalOcean cloud." 
+    seconditem="Create three virtual workload clusters for each default environment (development, staging & production)."
+/>
 
 The DigitalOcean provisioning process will:
 <CommonProvisionProcess firstitem="Create a Kubernetes management cluster in the DigitalOcean cloud."/>

--- a/versioned_docs/version-2.3/gcp/overview.mdx
+++ b/versioned_docs/version-2.3/gcp/overview.mdx
@@ -27,7 +27,10 @@ Google Cloud is in beta. Use at your own risks.
 :::
 
 The Google Cloud provisioning process will:
-<CommonProvisionProcess firstitem="Create a Kubernetes management cluster in Google Cloud."/>
+<CommonProvisionProcess 
+    firstitem="Create a Kubernetes management cluster in Google Cloud." 
+    seconditem="Create three virtual workload clusters for each default environment (development, staging & production)."
+/>
 
 <Tabs groupId="git_provider" defaultValue="github" queryString>
   <TabItem attributes={{ className: styles.github }} value="github" label={ <div className="git-tab"><img src="https://assets.kubefirst.com/console/github.svg" alt="GitHub logo" /><span>GitHub</span></div> }>

--- a/versioned_docs/version-2.3/k3d/overview.mdx
+++ b/versioned_docs/version-2.3/k3d/overview.mdx
@@ -22,7 +22,10 @@ import K3dLogo from '../img/k3d/logo.svg';
 # Overview
 
 The k3d provisioning process will:
-<CommonProvisionProcess firstitem="Create a multinode k3d Kubernetes cluster on your localhost." />
+<CommonProvisionProcess 
+    firstitem="Create a multinode k3d Kubernetes cluster on your localhost." 
+    seconditem="Create three namespaces for each default environment (development, staging & production). Note: This all runs in a single, multi-node cluster unlike other public clouds"
+/>
 
 <Tabs groupId="git_provider" defaultValue="github" queryString>
   <TabItem attributes={{ className: styles.github }} value="github" label={ <div className="git-tab"><img src="https://assets.kubefirst.com/console/github.svg" alt="GitHub logo" /><span>GitHub</span></div> }>

--- a/versioned_docs/version-2.3/vultr/overview.mdx
+++ b/versioned_docs/version-2.3/vultr/overview.mdx
@@ -29,7 +29,10 @@ Vultr is in beta. It is quite stable, but use at your own risks.
 :::
 
 The Vultr provisioning process will:
-<CommonProvisionProcess firstitem="Create a Kubernetes management cluster in the Vultr cloud."/>
+<CommonProvisionProcess 
+    firstitem="Create a Kubernetes management cluster in the Vultr cloud." 
+    seconditem="Create three virtual workload clusters for each default environment (development, staging & production)."
+/>
 
 <Tabs groupId="git_provider" defaultValue="github" queryString>
   <TabItem attributes={{ className: styles.github }} value="github" label={ <div className="git-tab"><img src="https://assets.kubefirst.com/console/github.svg" alt="GitHub logo" /><span>GitHub</span></div> }>

--- a/versioned_docs/version-2.4/akamai/overview.mdx
+++ b/versioned_docs/version-2.4/akamai/overview.mdx
@@ -35,7 +35,10 @@ Akamai is in beta. Use at your own risks.
 :::
 
 The Akamai provisioning process will:
-<CommonProvisionProcess firstitem="Create a Kubernetes management cluster in the Akamai cloud."/>
+<CommonProvisionProcess 
+    firstitem="Create a Kubernetes management cluster in the Akamai cloud."
+    seconditem="Create three virtual workload clusters for each default environment (development, staging & production)."
+/>
 
 <Tabs groupId="git_provider" defaultValue="github" queryString>
   <TabItem attributes={{ className: styles.github }} value="github" label={ <GitHubLogo /> }>

--- a/versioned_docs/version-2.4/aws/overview.mdx
+++ b/versioned_docs/version-2.4/aws/overview.mdx
@@ -25,7 +25,10 @@ import GitLabLogo from '../common/components/GitLabLogo.jsx'
 # Overview
 
 The AWS provisioning process will:
-<CommonProvisionProcess firstitem="Create a Kubernetes management cluster in the AWS cloud."/>
+<CommonProvisionProcess 
+    firstitem="Create a Kubernetes management cluster in the AWS cloud." 
+    seconditem="Create three virtual workload clusters for each default environment (development, staging & production)."
+/>
 
 <Tabs groupId="git_provider" defaultValue="github" queryString>
   <TabItem attributes={{ className: styles.github }} value="github" label={ <GitHubLogo /> }>

--- a/versioned_docs/version-2.4/civo/overview.mdx
+++ b/versioned_docs/version-2.4/civo/overview.mdx
@@ -25,7 +25,10 @@ import GitLabLogo from '../common/components/GitLabLogo.jsx'
 # Overview
 
 The Civo provisioning process will:
-<CommonProvisionProcess firstitem="Create a Kubernetes management cluster in the Civo cloud."/>
+<CommonProvisionProcess 
+    firstitem="Create a Kubernetes management cluster in the Civo cloud."
+    seconditem="Create three virtual workload clusters for each default environment (development, staging & production)."
+/>
 
 <Tabs groupId="git_provider" defaultValue="github" queryString>
   <TabItem attributes={{ className: styles.github }} value="github" label={ <GitHubLogo /> }>

--- a/versioned_docs/version-2.4/common/partials/common/_provision-process.mdx
+++ b/versioned_docs/version-2.4/common/partials/common/_provision-process.mdx
@@ -1,5 +1,5 @@
 - {props.firstitem}
-- Create three virtual workload clusters for each default environment (development, staging & production).
+- {props.seconditem}
 - Create a `gitops` Git repository from our [gitops-template](https://github.com/kubefirst/gitops-template) and store it in your selected Git provider.
 - Install Argo CD bootstrapped against your `gitops` repository so your repository powers the platform, and become your source of truth.
 - Install all the platform applications using GitOps (from the `/registry` folder in the `gitops` repository).

--- a/versioned_docs/version-2.4/do/overview.mdx
+++ b/versioned_docs/version-2.4/do/overview.mdx
@@ -26,7 +26,10 @@ import GitLabLogo from '../common/components/GitLabLogo.jsx'
 # Overview
 
 The DigitalOcean provisioning process will:
-<CommonProvisionProcess firstitem="Create a Kubernetes management cluster in the DigitalOcean cloud."/>
+<CommonProvisionProcess 
+    firstitem="Create a Kubernetes management cluster in the DigitalOcean cloud."
+    seconditem="Create three virtual workload clusters for each default environment (development, staging & production)."
+/>
 
 <Tabs groupId="git_provider" defaultValue="github" queryString>
   <TabItem attributes={{ className: styles.github }} value="github" label={ <GitHubLogo /> }>

--- a/versioned_docs/version-2.4/gcp/overview.mdx
+++ b/versioned_docs/version-2.4/gcp/overview.mdx
@@ -30,7 +30,10 @@ Google Cloud is in beta. Use at your own risks.
 :::
 
 The Google Cloud provisioning process will:
-<CommonProvisionProcess firstitem="Create a Kubernetes management cluster in Google Cloud."/>
+<CommonProvisionProcess 
+    firstitem="Create a Kubernetes management cluster in Google Cloud."
+    seconditem="Create three virtual workload clusters for each default environment (development, staging & production)."
+/>
 
 <Tabs groupId="git_provider" defaultValue="github" queryString>
   <TabItem attributes={{ className: styles.github }} value="github" label={ <GitHubLogo /> }>

--- a/versioned_docs/version-2.4/k3d/overview.mdx
+++ b/versioned_docs/version-2.4/k3d/overview.mdx
@@ -25,7 +25,10 @@ import GitLabLogo from '../common/components/GitLabLogo.jsx'
 # Overview
 
 The k3d provisioning process will:
-<CommonProvisionProcess firstitem="Create a multinode k3d Kubernetes cluster on your localhost." />
+<CommonProvisionProcess 
+    firstitem="Create a multinode k3d Kubernetes cluster on your localhost."
+    seconditem="Create three namespaces for each default environment (development, staging & production). Note: This all runs in a single, multi-node cluster unlike other public clouds"
+/>
 
 <Tabs groupId="git_provider" defaultValue="github" queryString>
   <TabItem attributes={{ className: styles.github }} value="github" label={ <GitHubLogo /> }>

--- a/versioned_docs/version-2.4/k3s/overview.mdx
+++ b/versioned_docs/version-2.4/k3s/overview.mdx
@@ -31,7 +31,10 @@ K3s is in beta. Use at your own risks.
 :::
 
 The K3s provisioning process will:
-<CommonProvisionProcess firstitem="Create a Kubernetes management cluster with K3s."/>
+<CommonProvisionProcess 
+    firstitem="Create a Kubernetes management cluster with K3s."
+    seconditem="Create three virtual workload clusters for each default environment (development, staging & production)."
+/>
 
 <Tabs groupId="git_provider" defaultValue="github" queryString>
   <TabItem value="github" attributes={{ className: styles.github }} label={ <GitHubLogo /> }>

--- a/versioned_docs/version-2.4/vultr/overview.mdx
+++ b/versioned_docs/version-2.4/vultr/overview.mdx
@@ -32,7 +32,10 @@ Vultr is in beta. It is quite stable, but use at your own risks.
 :::
 
 The Vultr provisioning process will:
-<CommonProvisionProcess firstitem="Create a Kubernetes management cluster in the Vultr cloud."/>
+<CommonProvisionProcess 
+    firstitem="Create a Kubernetes management cluster in the Vultr cloud."
+    seconditem="Create three virtual workload clusters for each default environment (development, staging & production)."
+/>
 
 <Tabs groupId="git_provider" defaultValue="github" queryString>
   <TabItem attributes={{ className: styles.github }} value="github" label={ <GitHubLogo /> }>

--- a/versioned_docs/version-2.5/akamai/overview.mdx
+++ b/versioned_docs/version-2.5/akamai/overview.mdx
@@ -35,7 +35,10 @@ Akamai is in beta. Use at your own risks.
 :::
 
 The Akamai provisioning process will:
-<CommonProvisionProcess firstitem="Create a Kubernetes management cluster in the Akamai cloud."/>
+<CommonProvisionProcess 
+    firstitem="Create a Kubernetes management cluster in the Akamai cloud."
+    seconditem="Create three virtual workload clusters for each default environment (development, staging & production)."
+/>
 
 <Tabs groupId="git_provider" defaultValue="github" queryString>
   <TabItem attributes={{ className: styles.github }} value="github" label={ <GitHubLogo /> }>

--- a/versioned_docs/version-2.5/aws/overview.mdx
+++ b/versioned_docs/version-2.5/aws/overview.mdx
@@ -25,7 +25,10 @@ import GitLabLogo from '../common/components/GitLabLogo.jsx'
 # Overview
 
 The AWS provisioning process will:
-<CommonProvisionProcess firstitem="Create a Kubernetes management cluster in the AWS cloud."/>
+<CommonProvisionProcess 
+    firstitem="Create a Kubernetes management cluster in the AWS cloud."
+    seconditem="Create three virtual workload clusters for each default environment (development, staging & production)."
+/>
 
 <Tabs groupId="git_provider" defaultValue="github" queryString>
   <TabItem attributes={{ className: styles.github }} value="github" label={ <GitHubLogo /> }>

--- a/versioned_docs/version-2.5/civo/overview.mdx
+++ b/versioned_docs/version-2.5/civo/overview.mdx
@@ -25,7 +25,10 @@ import GitLabLogo from '../common/components/GitLabLogo.jsx'
 # Overview
 
 The Civo provisioning process will:
-<CommonProvisionProcess firstitem="Create a Kubernetes management cluster in the Civo cloud."/>
+<CommonProvisionProcess 
+    firstitem="Create a Kubernetes management cluster in the Civo cloud."
+    seconditem="Create three virtual workload clusters for each default environment (development, staging & production)."
+/>
 
 <Tabs groupId="git_provider" defaultValue="github" queryString>
   <TabItem attributes={{ className: styles.github }} value="github" label={ <GitHubLogo /> }>

--- a/versioned_docs/version-2.5/common/partials/common/_provision-process.mdx
+++ b/versioned_docs/version-2.5/common/partials/common/_provision-process.mdx
@@ -1,5 +1,5 @@
 - {props.firstitem}
-- Create three virtual workload clusters for each default environment (development, staging & production).
+- {props.seconditem}
 - Create a `gitops` Git repository from our [gitops-template](https://github.com/kubefirst/gitops-template) and store it in your selected Git provider.
 - Install Argo CD bootstrapped against your `gitops` repository so your repository powers the platform, and become your source of truth.
 - Install all the platform applications using GitOps (from the `/registry` folder in the `gitops` repository).

--- a/versioned_docs/version-2.5/do/overview.mdx
+++ b/versioned_docs/version-2.5/do/overview.mdx
@@ -26,7 +26,10 @@ import GitLabLogo from '../common/components/GitLabLogo.jsx'
 # Overview
 
 The DigitalOcean provisioning process will:
-<CommonProvisionProcess firstitem="Create a Kubernetes management cluster in the DigitalOcean cloud."/>
+<CommonProvisionProcess 
+    firstitem="Create a Kubernetes management cluster in the DigitalOcean cloud."
+    seconditem="Create three virtual workload clusters for each default environment (development, staging & production)."
+/>
 
 <Tabs groupId="git_provider" defaultValue="github" queryString>
   <TabItem attributes={{ className: styles.github }} value="github" label={ <GitHubLogo /> }>

--- a/versioned_docs/version-2.5/gcp/overview.mdx
+++ b/versioned_docs/version-2.5/gcp/overview.mdx
@@ -30,7 +30,11 @@ Google Cloud is in beta. Use at your own risks.
 :::
 
 The Google Cloud provisioning process will:
-<CommonProvisionProcess firstitem="Create a Kubernetes management cluster in Google Cloud."/>
+<CommonProvisionProcess 
+    firstitem="Create a Kubernetes management cluster in Google Cloud."
+    seconditem="Create three virtual workload clusters for each default environment (development, staging & production)."
+
+/>
 
 <Tabs groupId="git_provider" defaultValue="github" queryString>
   <TabItem attributes={{ className: styles.github }} value="github" label={ <GitHubLogo /> }>

--- a/versioned_docs/version-2.5/k3d/overview.mdx
+++ b/versioned_docs/version-2.5/k3d/overview.mdx
@@ -25,7 +25,10 @@ import GitLabLogo from '../common/components/GitLabLogo.jsx'
 # Overview
 
 The k3d provisioning process will:
-<CommonProvisionProcess firstitem="Create a multinode k3d Kubernetes cluster on your localhost." />
+<CommonProvisionProcess 
+    firstitem="Create a multinode k3d Kubernetes cluster on your localhost." 
+    seconditem="Create three namespaces for each default environment (development, staging & production). Note: This all runs in a single, multi-node cluster unlike other public clouds"
+/>
 
 <Tabs groupId="git_provider" defaultValue="github" queryString>
   <TabItem attributes={{ className: styles.github }} value="github" label={ <GitHubLogo /> }>

--- a/versioned_docs/version-2.5/k3s/overview.mdx
+++ b/versioned_docs/version-2.5/k3s/overview.mdx
@@ -31,7 +31,10 @@ K3s is in beta. Use at your own risks.
 :::
 
 The K3s provisioning process will:
-<CommonProvisionProcess firstitem="Create a Kubernetes management cluster with K3s."/>
+<CommonProvisionProcess 
+    firstitem="Create a Kubernetes management cluster with K3s."
+    seconditem="Create three virtual workload clusters for each default environment (development, staging & production)."
+/>
 
 <Tabs groupId="git_provider" defaultValue="github" queryString>
   <TabItem value="github" attributes={{ className: styles.github }} label={ <GitHubLogo /> }>

--- a/versioned_docs/version-2.5/vultr/overview.mdx
+++ b/versioned_docs/version-2.5/vultr/overview.mdx
@@ -32,7 +32,10 @@ Vultr is in beta. It is quite stable, but use at your own risks.
 :::
 
 The Vultr provisioning process will:
-<CommonProvisionProcess firstitem="Create a Kubernetes management cluster in the Vultr cloud."/>
+<CommonProvisionProcess 
+    firstitem="Create a Kubernetes management cluster in the Vultr cloud."
+    seconditem="Create three virtual workload clusters for each default environment (development, staging & production)."
+/>
 
 <Tabs groupId="git_provider" defaultValue="github" queryString>
   <TabItem attributes={{ className: styles.github }} value="github" label={ <GitHubLogo /> }>

--- a/versioned_docs/version-2.6/akamai/overview.mdx
+++ b/versioned_docs/version-2.6/akamai/overview.mdx
@@ -35,7 +35,10 @@ Akamai is in beta. Use at your own risks.
 :::
 
 The Akamai provisioning process will:
-<CommonProvisionProcess firstitem="Create a Kubernetes management cluster in the Akamai cloud."/>
+<CommonProvisionProcess 
+    firstitem="Create a Kubernetes management cluster in the Akamai cloud."
+    seconditem="Create three virtual workload clusters for each default environment (development, staging & production)."
+/>
 
 <Tabs groupId="git_provider" defaultValue="github" queryString>
   <TabItem attributes={{ className: styles.github }} value="github" label={ <GitHubLogo /> }>

--- a/versioned_docs/version-2.6/aws/overview.mdx
+++ b/versioned_docs/version-2.6/aws/overview.mdx
@@ -25,7 +25,10 @@ import GitLabLogo from '../common/components/GitLabLogo.jsx'
 # Overview
 
 The AWS provisioning process will:
-<CommonProvisionProcess firstitem="Create a Kubernetes management cluster in the AWS cloud."/>
+<CommonProvisionProcess 
+    firstitem="Create a Kubernetes management cluster in the AWS cloud."
+    seconditem="Create three virtual workload clusters for each default environment (development, staging & production)."
+/>
 
 <Tabs groupId="git_provider" defaultValue="github" queryString>
   <TabItem attributes={{ className: styles.github }} value="github" label={ <GitHubLogo /> }>

--- a/versioned_docs/version-2.6/civo/overview.mdx
+++ b/versioned_docs/version-2.6/civo/overview.mdx
@@ -25,7 +25,10 @@ import GitLabLogo from '../common/components/GitLabLogo.jsx'
 # Overview
 
 The Civo provisioning process will:
-<CommonProvisionProcess firstitem="Create a Kubernetes management cluster in the Civo cloud."/>
+<CommonProvisionProcess 
+    firstitem="Create a Kubernetes management cluster in the Civo cloud."
+    seconditem="Create three virtual workload clusters for each default environment (development, staging & production)."
+/>
 
 <Tabs groupId="git_provider" defaultValue="github" queryString>
   <TabItem attributes={{ className: styles.github }} value="github" label={ <GitHubLogo /> }>

--- a/versioned_docs/version-2.6/common/partials/common/_provision-process.mdx
+++ b/versioned_docs/version-2.6/common/partials/common/_provision-process.mdx
@@ -1,5 +1,5 @@
 - {props.firstitem}
-Create three virtual workload clusters for each default environment (development, staging & production).
+- {props.seconditem}
 - Create a `gitops` Git repository from our [gitops-template](https://github.com/kubefirst/gitops-template) and store it in your selected Git provider.
 - Install Argo CD bootstrapped against your `gitops` repository so your repository powers the platform, and become your source of truth.
 - Install all the platform applications using GitOps (from the `/registry` folder in the `gitops` repository).

--- a/versioned_docs/version-2.6/common/partials/common/_provision-process.mdx
+++ b/versioned_docs/version-2.6/common/partials/common/_provision-process.mdx
@@ -1,5 +1,5 @@
 - {props.firstitem}
-- Create three virtual workload clusters for each default environment (development, staging & production).
+Create three virtual workload clusters for each default environment (development, staging & production).
 - Create a `gitops` Git repository from our [gitops-template](https://github.com/kubefirst/gitops-template) and store it in your selected Git provider.
 - Install Argo CD bootstrapped against your `gitops` repository so your repository powers the platform, and become your source of truth.
 - Install all the platform applications using GitOps (from the `/registry` folder in the `gitops` repository).

--- a/versioned_docs/version-2.6/do/overview.mdx
+++ b/versioned_docs/version-2.6/do/overview.mdx
@@ -26,7 +26,10 @@ import GitLabLogo from '../common/components/GitLabLogo.jsx'
 # Overview
 
 The DigitalOcean provisioning process will:
-<CommonProvisionProcess firstitem="Create a Kubernetes management cluster in the DigitalOcean cloud."/>
+<CommonProvisionProcess 
+    firstitem="Create a Kubernetes management cluster in the DigitalOcean cloud."
+    seconditem="Create three virtual workload clusters for each default environment (development, staging & production)."
+/>
 
 <Tabs groupId="git_provider" defaultValue="github" queryString>
   <TabItem attributes={{ className: styles.github }} value="github" label={ <GitHubLogo /> }>

--- a/versioned_docs/version-2.6/gcp/overview.mdx
+++ b/versioned_docs/version-2.6/gcp/overview.mdx
@@ -30,7 +30,10 @@ Google Cloud is in beta. Use at your own risks.
 :::
 
 The Google Cloud provisioning process will:
-<CommonProvisionProcess firstitem="Create a Kubernetes management cluster in Google Cloud."/>
+<CommonProvisionProcess 
+    firstitem="Create a Kubernetes management cluster in Google cloud."
+    seconditem="Create three virtual workload clusters for each default environment (development, staging & production)."
+/>
 
 <Tabs groupId="git_provider" defaultValue="github" queryString>
   <TabItem attributes={{ className: styles.github }} value="github" label={ <GitHubLogo /> }>

--- a/versioned_docs/version-2.6/k3d/overview.mdx
+++ b/versioned_docs/version-2.6/k3d/overview.mdx
@@ -25,7 +25,10 @@ import GitLabLogo from '../common/components/GitLabLogo.jsx'
 # Overview
 
 The k3d provisioning process will:
-<CommonProvisionProcess firstitem="Create a multinode k3d Kubernetes cluster on your localhost." />
+<CommonProvisionProcess 
+    firstitem="Create a multinode k3d Kubernetes cluster on your localhost."
+    seconditem="Create three namespaces for each default environment (development, staging & production). Note: This all runs in a single, multi-node cluster unlike other public clouds"
+/>
 
 <Tabs groupId="git_provider" defaultValue="github" queryString>
   <TabItem attributes={{ className: styles.github }} value="github" label={ <GitHubLogo /> }>

--- a/versioned_docs/version-2.6/k3s/overview.mdx
+++ b/versioned_docs/version-2.6/k3s/overview.mdx
@@ -31,7 +31,10 @@ K3s is in beta. Use at your own risks.
 :::
 
 The K3s provisioning process will:
-<CommonProvisionProcess firstitem="Create a Kubernetes management cluster with K3s."/>
+<CommonProvisionProcess 
+    firstitem="Create a Kubernetes management cluster with K3s."
+    seconditem="Create three virtual workload clusters for each default environment (development, staging & production)."
+/>
 
 <Tabs groupId="git_provider" defaultValue="github" queryString>
   <TabItem value="github" attributes={{ className: styles.github }} label={ <GitHubLogo /> }>

--- a/versioned_docs/version-2.6/vultr/overview.mdx
+++ b/versioned_docs/version-2.6/vultr/overview.mdx
@@ -32,7 +32,10 @@ Vultr is in beta. It is quite stable, but use at your own risks.
 :::
 
 The Vultr provisioning process will:
-<CommonProvisionProcess firstitem="Create a Kubernetes management cluster in the Vultr cloud."/>
+<CommonProvisionProcess 
+    firstitem="Create a Kubernetes management cluster in the Vultr cloud."
+    seconditem="Create three virtual workload clusters for each default environment (development, staging & production)."
+/>
 
 <Tabs groupId="git_provider" defaultValue="github" queryString>
   <TabItem attributes={{ className: styles.github }} value="github" label={ <GitHubLogo /> }>

--- a/versioned_docs/version-2.7/akamai/overview.mdx
+++ b/versioned_docs/version-2.7/akamai/overview.mdx
@@ -35,7 +35,10 @@ Akamai is in beta. Use at your own risks.
 :::
 
 The Akamai provisioning process will:
-<CommonProvisionProcess firstitem="Create a Kubernetes management cluster in the Akamai cloud."/>
+<CommonProvisionProcess 
+    firstitem="Create a Kubernetes management cluster in the Akamai cloud."
+    seconditem="Create three virtual workload clusters for each default environment (development, staging & production)."
+/>
 
 <Tabs groupId="git_provider" defaultValue="github" queryString>
   <TabItem attributes={{ className: styles.github }} value="github" label={ <GitHubLogo /> }>

--- a/versioned_docs/version-2.7/aws/overview.mdx
+++ b/versioned_docs/version-2.7/aws/overview.mdx
@@ -25,7 +25,10 @@ import GitLabLogo from '../common/components/GitLabLogo.jsx'
 # Overview
 
 The AWS provisioning process will:
-<CommonProvisionProcess firstitem="Create a Kubernetes management cluster in the AWS cloud."/>
+<CommonProvisionProcess 
+    firstitem="Create a Kubernetes management cluster in the AWS cloud."
+    seconditem="Create three virtual workload clusters for each default environment (development, staging & production)."
+/>
 
 <Tabs groupId="git_provider" defaultValue="github" queryString>
   <TabItem attributes={{ className: styles.github }} value="github" label={ <GitHubLogo /> }>

--- a/versioned_docs/version-2.7/azure/overview.mdx
+++ b/versioned_docs/version-2.7/azure/overview.mdx
@@ -29,7 +29,10 @@ Azure is in beta. Use at your own risk.
 :::
 
 The Azure provisioning process will:
-<CommonProvisionProcess firstitem="Create a Kubernetes management cluster in the Azure cloud."/>
+<CommonProvisionProcess 
+    firstitem="Create a Kubernetes management cluster in the Azure cloud."
+    seconditem="Create three virtual workload clusters for each default environment (development, staging & production)."
+/>
 
 <Tabs groupId="git_provider" defaultValue="github" queryString>
   <TabItem attributes={{ className: styles.github }} value="github" label={ <GitHubLogo /> }>

--- a/versioned_docs/version-2.7/civo/overview.mdx
+++ b/versioned_docs/version-2.7/civo/overview.mdx
@@ -25,7 +25,10 @@ import GitLabLogo from '../common/components/GitLabLogo.jsx'
 # Overview
 
 The Civo provisioning process will:
-<CommonProvisionProcess firstitem="Create a Kubernetes management cluster in the Civo cloud."/>
+<CommonProvisionProcess 
+    firstitem="Create a Kubernetes management cluster in the Civo cloud."
+    seconditem="Create three virtual workload clusters for each default environment (development, staging & production)."
+/>
 
 <Tabs groupId="git_provider" defaultValue="github" queryString>
   <TabItem attributes={{ className: styles.github }} value="github" label={ <GitHubLogo /> }>

--- a/versioned_docs/version-2.7/common/partials/common/_provision-process.mdx
+++ b/versioned_docs/version-2.7/common/partials/common/_provision-process.mdx
@@ -1,4 +1,5 @@
 - {props.firstitem}
+- {props.seconditem}
 - Create a `gitops` Git repository from our [gitops-template](https://github.com/kubefirst/gitops-template) and store it in your selected Git provider.
 - Install Argo CD bootstrapped against your `gitops` repository so your repository powers the platform, and become your source of truth.
 - Install all the platform applications using GitOps (from the `/registry` folder in the `gitops` repository).

--- a/versioned_docs/version-2.7/do/overview.mdx
+++ b/versioned_docs/version-2.7/do/overview.mdx
@@ -26,7 +26,10 @@ import GitLabLogo from '../common/components/GitLabLogo.jsx'
 # Overview
 
 The DigitalOcean provisioning process will:
-<CommonProvisionProcess firstitem="Create a Kubernetes management cluster in the DigitalOcean cloud."/>
+<CommonProvisionProcess 
+    firstitem="Create a Kubernetes management cluster in the DigitalOcean cloud."
+    seconditem="Create three virtual workload clusters for each default environment (development, staging & production)."
+/>
 
 <Tabs groupId="git_provider" defaultValue="github" queryString>
   <TabItem attributes={{ className: styles.github }} value="github" label={ <GitHubLogo /> }>

--- a/versioned_docs/version-2.7/gcp/overview.mdx
+++ b/versioned_docs/version-2.7/gcp/overview.mdx
@@ -30,7 +30,10 @@ Google Cloud is in beta. Use at your own risks.
 :::
 
 The Google Cloud provisioning process will:
-<CommonProvisionProcess firstitem="Create a Kubernetes management cluster in Google Cloud."/>
+<CommonProvisionProcess 
+    firstitem="Create a Kubernetes management cluster in Google cloud."
+    seconditem="Create three virtual workload clusters for each default environment (development, staging & production)."
+/>
 
 <Tabs groupId="git_provider" defaultValue="github" queryString>
   <TabItem attributes={{ className: styles.github }} value="github" label={ <GitHubLogo /> }>

--- a/versioned_docs/version-2.7/k3d/overview.mdx
+++ b/versioned_docs/version-2.7/k3d/overview.mdx
@@ -25,7 +25,10 @@ import GitLabLogo from '../common/components/GitLabLogo.jsx'
 # Overview
 
 The k3d provisioning process will:
-<CommonProvisionProcess firstitem="Create a multinode k3d Kubernetes cluster on your localhost." />
+<CommonProvisionProcess 
+    firstitem="Create a multinode k3d Kubernetes cluster on your localhost." 
+    seconditem="Create three namespaces for each default environment (development, staging & production). Note: This all runs in a single, multi-node cluster unlike other public clouds"
+/>
 
 <Tabs groupId="git_provider" defaultValue="github" queryString>
   <TabItem attributes={{ className: styles.github }} value="github" label={ <GitHubLogo /> }>

--- a/versioned_docs/version-2.7/k3s/overview.mdx
+++ b/versioned_docs/version-2.7/k3s/overview.mdx
@@ -31,7 +31,10 @@ K3s is in beta. Use at your own risks.
 :::
 
 The K3s provisioning process will:
-<CommonProvisionProcess firstitem="Create a Kubernetes management cluster with K3s."/>
+<CommonProvisionProcess 
+    firstitem="Create a Kubernetes management cluster with K3s."
+    seconditem="Create three virtual workload clusters for each default environment (development, staging & production)."
+/>
 
 <Tabs groupId="git_provider" defaultValue="github" queryString>
   <TabItem value="github" attributes={{ className: styles.github }} label={ <GitHubLogo /> }>

--- a/versioned_docs/version-2.7/vultr/overview.mdx
+++ b/versioned_docs/version-2.7/vultr/overview.mdx
@@ -32,7 +32,10 @@ Vultr is in beta. It is quite stable, but use at your own risks.
 :::
 
 The Vultr provisioning process will:
-<CommonProvisionProcess firstitem="Create a Kubernetes management cluster in the Vultr cloud."/>
+<CommonProvisionProcess 
+    firstitem="Create a Kubernetes management cluster in the Vultr cloud."
+    seconditem="Create three virtual workload clusters for each default environment (development, staging & production)."
+/>
 
 <Tabs groupId="git_provider" defaultValue="github" queryString>
   <TabItem attributes={{ className: styles.github }} value="github" label={ <GitHubLogo /> }>


### PR DESCRIPTION
## Description
When spinning things up on k3d (local), you actually end up with a single, multi-node cluster, and separate namespaces for your workloads, rather than separate workload clusters, like other clouds. This slightly tweaks the `_provision-process` partial to take an extra argument so that we can set a different second bullet point, to note this discrepancy

## Related Issue(s)
Fixes #844

## How to test
`npm start`, and then look through all doc versions for all clouds >= 2.3. The verbiage is still contains the bullet about multiple clusters for workloads, but for k3d the verbiage is changed to 

> Create three namespaces for each default environment (development, staging & production). Note: This all runs in a single, multi-node cluster unlike other public clouds

Current verbiage retained for most clouds:

![image](https://github.com/user-attachments/assets/31b23bcb-33a2-4e7b-aebd-abb6574ca656)

Updated verbiage for k3d specifically:

![image](https://github.com/user-attachments/assets/7ef3b109-a800-4bbf-ab68-f1c960254771)


# Open Question
Is k3s like k3d, where it will create namespaces instead of multiple workload clusters? If so we can tweak the verbiage to match the `k3d` verbiage instead. I haven't spun up Kubefirst on k3s yet so I' not sure, this is just from my reference of spinning things up on k3d
