### PR TITLE
fix: remove beta mention for all clouds in overview pages

### DIFF
--- a/docs/akamai/overview.mdx
+++ b/docs/akamai/overview.mdx
@@ -24,12 +24,6 @@ import GitLabLogo from '../common/components/GitLabLogo.jsx'
 
 # Overview
 
-:::caution
-
-Akamai is in beta. Use at your own risks.
-
-:::
-
 :::note
 [Linode has been acquired by Akamai in 2022](https://www.akamai.com/newsroom/press-release/akamai-completes-acquisition-of-linode), but the branding is still in some cases, like for the CLI used to connect to Kubernetes on Akamai. If you see Linode written in the documentation, keep in mind that it is in reality Akamai, but that we have to use the previous brand because Akamai still do.
 :::

--- a/docs/azure/overview.mdx
+++ b/docs/azure/overview.mdx
@@ -22,12 +22,6 @@ import GitLabLogo from '../common/components/GitLabLogo.jsx'
 
 # Overview
 
-:::caution
-
-Azure is in beta. Use at your own risk.
-
-:::
-
 The Azure provisioning process will:
 <CommonProvisionProcess firstitem="Create a Kubernetes management cluster in the Azure cloud."/>
 

--- a/docs/gcp/overview.mdx
+++ b/docs/gcp/overview.mdx
@@ -23,12 +23,6 @@ import GitLabLogo from '../common/components/GitLabLogo.jsx'
 
 # Overview
 
-:::caution
-
-Google Cloud is in beta. Use at your own risks.
-
-:::
-
 The Google Cloud provisioning process will:
 <CommonProvisionProcess firstitem="Create a Kubernetes management cluster in Google Cloud."/>
 

--- a/docs/k3s/overview.mdx
+++ b/docs/k3s/overview.mdx
@@ -24,12 +24,6 @@ import GitLabLogo from '../common/components/GitLabLogo.jsx'
 
 # Overview
 
-:::caution
-
-K3s is in beta. Use at your own risks.
-
-:::
-
 The K3s provisioning process will:
 <CommonProvisionProcess firstitem="Create a Kubernetes management cluster with K3s."/>
 

--- a/docs/vultr/overview.mdx
+++ b/docs/vultr/overview.mdx
@@ -25,12 +25,6 @@ import GitLabLogo from '../common/components/GitLabLogo.jsx'
 
 # Overview
 
-:::caution
-
-Vultr is in beta. It is quite stable, but use at your own risks.
-
-:::
-
 The Vultr provisioning process will:
 <CommonProvisionProcess firstitem="Create a Kubernetes management cluster in the Vultr cloud."/>
 


### PR DESCRIPTION
As requested by @johndietz