### PR TITLE
fix: Updating blog URL

### DIFF
--- a/docs/common/partials/gitlab/_prerequisites.mdx
+++ b/docs/common/partials/gitlab/_prerequisites.mdx
@@ -9,5 +9,5 @@ GitLab SaaS offering has limitations that require us to use groups contrary to G
 :::
 
 :::info
-If you want to use GitLab self-managed, you can update your GitOps repository and Kubernetes cluster once the creation is done following [this tutorial](https://kubefirst.io/blog/self-hosting-gitlab/).
+If you want to use GitLab self-managed, you can update your GitOps repository and Kubernetes cluster once the creation is done following [this tutorial](https://blog.konstruct.io/self-hosting-gitlab/).
 :::

--- a/versioned_docs/version-2.7/common/partials/gitlab/_prerequisites.mdx
+++ b/versioned_docs/version-2.7/common/partials/gitlab/_prerequisites.mdx
@@ -9,5 +9,5 @@ GitLab SaaS offering has limitations that require us to use groups contrary to G
 :::
 
 :::info
-If you want to use GitLab self-managed, you can update your GitOps repository and Kubernetes cluster once the creation is done following [this tutorial](https://kubefirst.io/blog/self-hosting-gitlab/).
+If you want to use GitLab self-managed, you can update your GitOps repository and Kubernetes cluster once the creation is done following [this tutorial](https://blog.konstruct.io/self-hosting-gitlab/).
 :::


### PR DESCRIPTION
## Description
Fixing the blog URL referenced in the GitLab prerequisites. 

https://blog.konstruct.io/self-hosting-gitlab/

## Related Issue(s)
n/a

## How to test
Verify the link works. 
